### PR TITLE
[macOS] fixed a crash bug of using API available on macOS 10.14+

### DIFF
--- a/macos/classes/CocoaThreadedApplicationService.mm
+++ b/macos/classes/CocoaThreadedApplicationService.mm
@@ -646,10 +646,11 @@ ViewportWindow::windowPos() const noexcept
 void
 ViewportWindow::setWindowPos(const ImVec2 &value)
 {
-    const CGPoint point = [m_window convertPointFromBacking:CGPointMake(value.x, value.y)];
-    const CGFloat y = m_window.contentView.frame.size.height + point.y;
+    const NSRect rect = [m_window convertRectFromBacking:NSMakeRect(value.x, value.y, 0, 0)];
+    const CGPoint origin = rect.origin;
+    const CGFloat y = m_window.contentView.frame.size.height + origin.y;
     const NSRect frameRect =
-        [m_window frameRectForContentRect:NSMakeRect(point.x, m_window.screen.frame.size.height - y, 0, 0)];
+        [m_window frameRectForContentRect:NSMakeRect(origin.x, m_window.screen.frame.size.height - y, 0, 0)];
     [m_window setFrameOrigin:frameRect.origin];
 }
 
@@ -836,10 +837,12 @@ CocoaThreadedApplicationService::scrollWheelDelta(const NSEvent *event)
 Vector2SI32
 CocoaThreadedApplicationService::deviceScaleScreenPosition(const NSEvent *event, NSWindow *window) noexcept
 {
-    const NSPoint screenCursorPoint([window convertPointToScreen:event.locationInWindow]),
-        deviceCursorPoint([window convertPointToBacking:screenCursorPoint]);
-    const NSRect deviceScaleFrameRect = [window convertRectToBacking:window.screen.frame];
-    return Vector2SI32(deviceCursorPoint.x, deviceScaleFrameRect.size.height - deviceCursorPoint.y);
+    const NSPoint locationInWindow(event.locationInWindow);
+    const NSRect rectInWindow(NSMakeRect(locationInWindow.x, locationInWindow.y, 0, 0)),
+        screenCursorRect([window convertRectToScreen:rectInWindow]),
+        deviceCursorRect([window convertRectToBacking:screenCursorRect]),
+        deviceScaleFrameRect = [window convertRectToBacking:window.screen.frame];
+    return Vector2SI32(deviceCursorRect.origin.x, deviceScaleFrameRect.size.height - deviceCursorRect.origin.y);
 }
 
 const char *

--- a/macos/classes/MetalSkinDeformerFactory.mm
+++ b/macos/classes/MetalSkinDeformerFactory.mm
@@ -466,7 +466,6 @@ MetalSkinDeformerFactory::Deformer::initializeUberBuffer(
     if (!m_mutableUberBuffer) {
         const nanoem_rsize_t length = sizeof(constantData) + matrixBufferLength + morphWeightBufferLength;
         m_mutableUberBuffer = [m_parent->m_device newBufferWithLength:length options:MTLResourceStorageModeManaged];
-        nanoem_rsize_t bufferOffset = matrixBufferLength + morphWeightBufferLength;
         setLabel(m_mutableUberBuffer, "MutableUberBuffer");
 #if defined(NANOEM_ENABLE_DEBUG_LABEL)
         NSString *name = [[NSString alloc] initWithUTF8String:m_model->canonicalNameConstString()],
@@ -474,7 +473,7 @@ MetalSkinDeformerFactory::Deformer::initializeUberBuffer(
                  *constantBufferName = [[NSString alloc] initWithFormat:@"%@/Constant", prefix],
                  *morphWeightBufferName = [[NSString alloc] initWithFormat:@"%@/MorphWeights", prefix],
                  *matrixBufferName = [[NSString alloc] initWithFormat:@"%@/Matrices", prefix];
-        bufferOffset = 0;
+        nanoem_rsize_t bufferOffset = 0;
         [m_mutableUberBuffer addDebugMarker:constantBufferName range:NSMakeRange(bufferOffset, sizeof(constantData))];
         bufferOffset += sizeof(constantData);
         [m_mutableUberBuffer addDebugMarker:matrixBufferName range:NSMakeRange(bufferOffset, matrixBufferLength)];


### PR DESCRIPTION
## Summary

This PR fixes a crash bug when macOS is 10.13 or earlier is used

## Details

`[NSWindow convertPointFromBacking:]` is available on macOS 10.14 or later so macOS 10.13 or earlier cannot use the selector and will crash as unknown selector. This PR replaces `[NSWindow convertPointFromBacking:]` and its related with `[NSWindow convertRectFromBacking]` and rect related selector to resolve.

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
