### PR TITLE
[nanodxm] prevent null pointer access

### DIFF
--- a/dependencies/nanodxm/nanodxm.c
+++ b/dependencies/nanodxm/nanodxm.c
@@ -441,7 +441,7 @@ nanodxmDocumentParseTextureFilename(nanodxm_buffer_t *buffer, nanodxm_uint8_t **
     nanodxmBufferSkipLine(buffer);
     nanodxmBufferSkipSpaces(buffer);
     str_begin = (const char *) nanodxmBufferGetDataPtr(buffer);
-    if (*str_begin == '"') {
+    if (str_begin && *str_begin == '"') {
         str_begin++;
         if ((str_end = strchr(str_begin, '"')) != NULL) {
             length = str_end - str_begin;
@@ -452,11 +452,11 @@ nanodxmDocumentParseTextureFilename(nanodxm_buffer_t *buffer, nanodxm_uint8_t **
             nanodxmBufferSkipSpaces(buffer);
             *output = ptr;
         }
-        else {
+        else if (output) {
             *output = NULL;
         }
     }
-    else {
+    else if (output) {
         *output = NULL;
     }
 }


### PR DESCRIPTION
## Summary

This PR fixed a crash bug at loading a `*.x` file with satisfaction of specific condition.

## Details

(none)

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
