### PR TITLE
[github] runs CodeQL job only on main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,7 @@ jobs:
           cd $GITHUB_WORKSPACE/out/core
           cmake --build . --target test
   codeql:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     env:
       FX9_BUILD_DEPENDENCIES_DIRECTORY: ${{ github.workspace }}/out/dependencies


### PR DESCRIPTION
## Summary

This PR restricts running CodeQL only on main branch due to time expensive job (takes 20~ minutes).

## Details

(none)

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
