### PR TITLE
[plugin] add standalone WASM build support of plugin_ssb

### DIFF
--- a/emapp/plugins/ssb/CMakeLists.txt
+++ b/emapp/plugins/ssb/CMakeLists.txt
@@ -1,29 +1,38 @@
 set(_plugin_name plugin_ssb)
+if(NOT PROJECT_SOURCE_DIR)
+  project(plugin_ssb)
+  cmake_minimum_required(VERSION 3.5)
+  set(_project_source_dir "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
+  set(WASM_PLUGIN ON)
+else()
+  set(_project_source_dir ${PROJECT_SOURCE_DIR})
+endif()
 set(_plugin_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/ssb.cc
-  ${PROJECT_SOURCE_DIR}/nanoem/nanoem.c
-  ${PROJECT_SOURCE_DIR}/nanoem/ext/mutable.c
-  ${PROJECT_SOURCE_DIR}/dependencies/protobuf-c/protobuf-c/protobuf-c.c
-  ${PROJECT_SOURCE_DIR}/emapp/src/protoc/common.pb-c.c
-  ${PROJECT_SOURCE_DIR}/emapp/src/protoc/plugin.pb-c.c)
+  ${_project_source_dir}/nanoem/nanoem.c
+  ${_project_source_dir}/nanoem/ext/mutable.c
+  ${_project_source_dir}/dependencies/protobuf-c/protobuf-c/protobuf-c.c
+  ${_project_source_dir}/emapp/src/protoc/common.pb-c.c
+  ${_project_source_dir}/emapp/src/protoc/plugin.pb-c.c)
 
-if(EMSCRIPTEN)
-  add_executable(${_plugin_name} ${_plugin_sources})
-  set_target_properties(${_plugin_name} PROPERTIES LINK_FLAGS "-s WASM=1 -s STANDALONE_WASM -s ALLOW_MEMORY_GROWTH")
-else()
-  add_library(${_plugin_name} SHARED ${_plugin_sources})
-  set_target_properties(${_plugin_name} PROPERTIES OUTPUT_NAME ${_plugin_name} PREFIX "" DEFINE_SYMBOL "")
-  if(MSVC)
-    set_property(TARGET ${_plugin_name} PROPERTY COMPILE_DEFINITIONS NANOEM_BUILDING_DLL NANOEM_DLL_EXPORTS)
-    set_property(TARGET ${_plugin_name} PROPERTY COMPILE_OPTIONS "-utf-8")
-  endif()
+add_library(${_plugin_name} SHARED ${_plugin_sources})
+if(WASM_PLUGIN)
+  set_target_properties(${_plugin_name} PROPERTIES SUFFIX ".wasm" NO_SONAME TRUE)
+  target_compile_definitions(${_plugin_name} PRIVATE WASM_WASI_SDK)
+  target_compile_options(${_plugin_name} PRIVATE -fno-exceptions)
+  target_link_options(${_plugin_name} PRIVATE -Wl,--no-entry -Wl,--export-all)
+endif()
+set_target_properties(${_plugin_name} PROPERTIES OUTPUT_NAME ${_plugin_name} PREFIX "" DEFINE_SYMBOL "")
+if(MSVC)
+  set_property(TARGET ${_plugin_name} PROPERTY COMPILE_DEFINITIONS NANOEM_BUILDING_DLL NANOEM_DLL_EXPORTS)
+  set_property(TARGET ${_plugin_name} PROPERTY COMPILE_OPTIONS "-utf-8")
 endif()
 set_property(TARGET ${_plugin_name} PROPERTY FOLDER plugins)
 set_property(TARGET ${_plugin_name} PROPERTY INCLUDE_DIRECTORIES
-  ${PROJECT_SOURCE_DIR}
-  ${PROJECT_SOURCE_DIR}/dependencies/protobuf-c
-  ${PROJECT_SOURCE_DIR}/dependencies/glm
-  ${PROJECT_SOURCE_DIR}/emapp/src/protoc)
+  ${_project_source_dir}
+  ${_project_source_dir}/dependencies/protobuf-c
+  ${_project_source_dir}/dependencies/glm
+  ${_project_source_dir}/emapp/src/protoc)
 
 # install(TARGETS ${_plugin_name} DESTINATION .)
 #set(CPACK_GENERATOR "ZIP")

--- a/emapp/plugins/ssb/ssb.cc
+++ b/emapp/plugins/ssb/ssb.cc
@@ -19,20 +19,12 @@
 #include <unordered_set>
 #include <vector>
 
-#define NANOEM_WASM_API extern "C"
-
 #ifndef NANOEM_DECL_API
 #define NANOEM_DECL_API extern "C"
 #endif /* NANOEM_DECL_API */
 #ifndef APIENTRY
 #define APIENTRY
 #endif /* APIENTRY */
-
-#ifdef EMSCRIPTEN
-#include <emscripten/emscripten.h>
-#undef APIENTRY
-#define APIENTRY EMSCRIPTEN_KEEPALIVE
-#endif
 
 namespace {
 
@@ -1834,98 +1826,6 @@ struct nanoem_application_plugin_model_io_t : SemiStandardBonePlugin {
 
 } /* namespace anonymous */
 
-NANOEM_WASM_API nanoem_wasm_plugin_model_io_t *APIENTRY
-nanoemWASMPluginModelIOCreate()
-{
-    return new nanoem_wasm_plugin_model_io_t;
-}
-
-NANOEM_WASM_API void APIENTRY
-nanoemWASMPluginModelIOSetLanguage(nanoem_wasm_plugin_model_io_t *instance, nanoem_u32_t value)
-{
-    if (instance) {
-        instance->setLanguage(value);
-    }
-}
-
-NANOEM_WASM_API const char *APIENTRY
-nanoemWASMPluginModelIOGetName(const nanoem_wasm_plugin_model_io_t *instance)
-{
-    return instance ? instance->name() : nullptr;
-}
-
-NANOEM_WASM_API void APIENTRY
-nanoemWASMPluginModelIOSetInputModelData(nanoem_wasm_plugin_model_io_t *instance, nanoem_u8_t *data, nanoem_u32_t size)
-{
-    if (instance && data && size > 0) {
-        nanoem_status_t status = NANOEM_STATUS_SUCCESS;
-        instance->setInputData(data, size, &status);
-    }
-}
-
-NANOEM_WASM_API bool APIENTRY
-nanoemWASMPluginModelIOExecute(nanoem_wasm_plugin_model_io_t *instance)
-{
-    return instance ? instance->execute() : false;
-}
-
-NANOEM_WASM_API nanoem_u32_t APIENTRY
-nanoemWASMPluginModelIOGetOutputModelDataSize(const nanoem_wasm_plugin_model_io_t *instance)
-{
-    return instance ? instance->outputModelDataSize() : 0;
-}
-
-NANOEM_WASM_API const nanoem_u8_t *APIENTRY
-nanoemWASMPluginModelIOGetOutputModelData(const nanoem_wasm_plugin_model_io_t *instance)
-{
-    return instance ? instance->outputModelData() : nullptr;
-}
-
-NANOEM_WASM_API bool APIENTRY
-nanoemWASMPluginModelIOLoadUIWindowLayout(nanoem_wasm_plugin_model_io_t *instance)
-{
-    return instance ? instance->loadWindowLayout() : false;
-}
-
-NANOEM_WASM_API void APIENTRY
-nanoemWASMPluginModelIOSetUIComponentLayoutData(
-    nanoem_wasm_plugin_model_io_t *instance, const char *name, nanoem_u8_t *data, nanoem_u32_t size)
-{
-    if (instance) {
-        instance->setComponentLayoutData(name, data, size);
-    }
-}
-
-NANOEM_WASM_API nanoem_u32_t APIENTRY
-nanoemWASMPluginModelIOGetUIWindowLayoutDataSize(const nanoem_wasm_plugin_model_io_t *instance)
-{
-    return instance ? instance->windowLayoutDataSize() : 0;
-}
-
-NANOEM_WASM_API const nanoem_u8_t *APIENTRY
-nanoemWASMPluginModelIOGetUIWindowLayoutData(const nanoem_wasm_plugin_model_io_t *instance)
-{
-    return instance ? instance->windowLayoutData() : nullptr;
-}
-
-NANOEM_WASM_API const char *APIENTRY
-nanoemWASMPluginModelIOGetFailureReason(const nanoem_wasm_plugin_model_io_t *instance)
-{
-    return instance ? instance->failureReason() : nullptr;
-}
-
-NANOEM_WASM_API const char *APIENTRY
-nanoemWASMPluginModelIOGetRecoverySuggestion(const nanoem_wasm_plugin_model_io_t *instance)
-{
-    return instance ? instance->recoverySuggestion() : nullptr;
-}
-
-NANOEM_WASM_API void APIENTRY
-nanoemWASMPluginModelIODestroy(nanoem_wasm_plugin_model_io_t *instance)
-{
-    delete instance;
-}
-
 NANOEM_DECL_API nanoem_u32_t APIENTRY
 nanoemApplicationPluginModelIOGetABIVersion(void)
 {
@@ -2120,3 +2020,10 @@ NANOEM_DECL_API void APIENTRY
 nanoemApplicationPluginModelIOTerminate(void)
 {
 }
+
+#ifdef WASM_WASI_SDK
+int main(int /* argc */, char ** /* argv */)
+{
+    return 0;
+}
+#endif


### PR DESCRIPTION
## Summary

This PR adds support of building plugin_ssb as WASM. 

## Details

The `plugin_wasm` will be introduced later PR based on [wasmer](https://github.com/wasmerio/wasmer) written in Rust, this PR prepares building WASM plugin for loading it from `plugin_wasm`.

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
