### PR TITLE
[dependencies] rebase upstream sokol

### DIFF
--- a/emapp/include/emapp/Forward.h
+++ b/emapp/include/emapp/Forward.h
@@ -296,7 +296,8 @@ typedef struct sg_limits {
     int max_image_size_3d; // max width/height/depth of SG_IMAGETYPE_3D images
     int max_image_size_array; // max width/height of SG_IMAGETYPE_ARRAY images
     int max_image_array_layers; // max number of layers in SG_IMAGETYPE_ARRAY images
-    int max_vertex_attrs; // <= SG_MAX_VERTEX_ATTRIBUTES (only on some GLES2 impls)
+    int max_vertex_attrs; // <= SG_MAX_VERTEX_ATTRIBUTES or less (on some GLES2 impls)
+    int gl_max_vertex_uniform_vectors; // <= GL_MAX_VERTEX_UNIFORM_VECTORS (only on GL backends)
 } sg_limits;
 
 typedef enum sg_resource_state {

--- a/emapp/resources/credits.md
+++ b/emapp/resources/credits.md
@@ -53,7 +53,7 @@ This software uses below libraries.
   - [sentry-native](https://github.com/getsentry/sentry-native)
     - [MIT](https://github.com/getsentry/sentry-native/blob/0.1.2/LICENSE)
   - [sokol](https://github.com/hkrn/sokol)
-    - [zlib](https://github.com/hkrn/sokol/blob/138adab3b09bad2885b5bedd6d598641a5f0bd8f/LICENSE)
+    - [zlib](https://github.com/hkrn/sokol/blob/4e3faa4acf67f3220649074591620e12244a94d9/LICENSE)
   - [SPIRV-Cross](https://github.com/KhronosGroup/SPIRV-Cross/)
     - [Apache License 2.0](https://github.com/KhronosGroup/SPIRV-Cross/blob/9acb9ec31f5a8ef80ea6b994bb77be787b08d3d1/LICENSE)
   - [SPIRV-Tools](https://github.com/KhronosGroup/SPIRV-Tools/)


### PR DESCRIPTION
## Summary

This PR updates [forked](https://github.com/hkrn/sokol/tree/20210724-blendop-minmax) [sokol](https://github.com/floooh/sokol/) to upstream as `20210724-blendop-minmax`.

## Details

(none)

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
