### PR TITLE
[win32] fix build due to change of #21

### DIFF
--- a/win32/include/WASAPIAudioPlayer.h
+++ b/win32/include/WASAPIAudioPlayer.h
@@ -79,7 +79,7 @@ private:
     void internalTransitStatePaused(Error &error) override;
     void internalTransitStateResumed(Error &error) override;
     void internalTransitStateStopped(Error &error) override;
-    bool initializeClient(IMMDevice *device, const Description &desc, Error &error);
+    bool initializeClient(IMMDevice *device, const WAVDescription &desc, Error &error);
     void destroyClient();
     void createAudioRenderThread();
     void createNullRenderThread();

--- a/win32/src/WASAPIAudioPlayer.cc
+++ b/win32/src/WASAPIAudioPlayer.cc
@@ -184,7 +184,7 @@ WASAPIAudioPlayer::seek(const IAudioPlayer::Rational &value)
 }
 
 bool
-WASAPIAudioPlayer::initializeClient(IMMDevice *device, const Description &desc, Error &error)
+WASAPIAudioPlayer::initializeClient(IMMDevice *device, const WAVDescription &desc, Error &error)
 {
     const Format &format = desc.m_formatData;
     WAVEFORMATEX requestFormat = {};


### PR DESCRIPTION
## Summary

This PR fixes build failure on win32 due to change of #21

## Details

#21 renamed `Description` to `WAVDescription` but didn't follow on win32.

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
