### PR TITLE
[misc] revise build flow, fixes #23 and #25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
-.python
-.envrc
-build
-deps
-
-nanoem/nanoem.cc
+# build artifact
+/**/out
 
 # document
 docs/_build
@@ -12,33 +8,21 @@ docs/_templates
 docs/.venv
 docs/conf.py
 
+# nanoem
+nanoem/nanoem.cc
+
 # emapp
 emapp/plugins/PEPlugin/bin
 emapp/plugins/PEPlugin/obj
 emapp/resources/translations/*/all.txt
 emapp/resources/translations/*/merge.pl
 
-# IDEA, QtCreator, Visual Studio Code
-browse.VC.db
-.idea
-*.user
-
-scripts/docker/data
-
 # manual checkout
-dependencies/dawn
-dependencies/depot_tools
 dependencies/ffmpeg
 dependencies/icu
 dependencies/optick
-dependencies/sdl
 dependencies/yaml-cpp
 
-# ansible
-*.retry
-ansible/roles/nanoem/files/id_rsa*
-
 # rust
-/target
-rust/viewer
+/rust/**/target
 **/*.rs.bk

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ nanoem is an [MMD (MikuMikuDance)](https://sites.google.com/view/vpvp/) compatib
 See also [GitHub Action Workflow](.github/workflows/main.yml).
 
 ```bash
-git submodule update --init --recurse
+git submodule update --init --recursive
 
 # needs setting NANOEM_TARGET_COMPILER explicitly when the compiler is clang (default is gcc on Linux)
 export NANOEM_TARGET_COMPILER=clang

--- a/scripts/build.cmake
+++ b/scripts/build.cmake
@@ -600,7 +600,7 @@ function(cleanup_all_repositories)
   foreach(item ${all_repositories})
     string(STRIP "${CMAKE_CURRENT_SOURCE_DIR}/dependencies/${item}" _path)
     execute_process(COMMAND ${GIT_EXECUTABLE} checkout -- . WORKING_DIRECTORY ${_path})
-    execute_process(COMMAND ${GIT_EXECUTABLE} clean -df -e build WORKING_DIRECTORY ${_path})
+    execute_process(COMMAND ${GIT_EXECUTABLE} clean -df -e out WORKING_DIRECTORY ${_path})
   endforeach()
 endfunction()
 
@@ -623,23 +623,19 @@ if(NOT OSX_TARGET)
 endif()
 set(CMAKE_FIND_LIBRARY_PREFIXES "lib;")
 set(CMAKE_FIND_LIBRARY_SUFFIXES ".so;.a;.lib")
-find_program(PATCH_EXECUTABLE_PATH NAME patch PATHS "${CMAKE_CURRENT_SOURCE_DIR}" "C:/Program Files (x86)/GnuWin32/bin")
 find_package(Git REQUIRED)
-if(PATCH_EXECUTABLE_PATH AND GIT_FOUND)
-  execute_process(COMMAND ${GIT_EXECUTABLE} checkout -- .
-                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/bullet3
-                  RESULT_VARIABLE result)
-  execute_process(COMMAND ${PATCH_EXECUTABLE_PATH} -p1
-                  INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/bullet-2.76.diff
-                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/bullet3
-                  RESULT_VARIABLE result)
-  execute_process(COMMAND ${GIT_EXECUTABLE} checkout -- .
-                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/glslang)
-  file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/glslang/glslang/Include/InfoSink.h input_info_sink_h NEWLINE_CONSUME)
-  # due to error detection of LLVM for windows, replace "UNKNOWN ERROR :" to "UNKNOWN :"
-  string(REPLACE "UNKNOWN ERROR:" "UNKNOWN:" output_info_sink_h "${input_info_sink_h}")
-  file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/glslang/glslang/Include/InfoSink.h ${output_info_sink_h})
-endif()
+execute_process(COMMAND ${GIT_EXECUTABLE} checkout -- .
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/bullet3
+                RESULT_VARIABLE result)
+execute_process(COMMAND ${GIT_EXECUTABLE} apply ${CMAKE_CURRENT_SOURCE_DIR}/cmake/bullet-2.76.diff
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/bullet3
+                RESULT_VARIABLE result)
+execute_process(COMMAND ${GIT_EXECUTABLE} checkout -- .
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/glslang)
+file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/glslang/glslang/Include/InfoSink.h input_info_sink_h NEWLINE_CONSUME)
+# due to error detection of LLVM for windows, replaccde "UNKNOWN ERROR :" to "UNKNOWN :"
+string(REPLACE "UNKNOWN ERROR:" "UNKNOWN:" output_info_sink_h "${input_info_sink_h}")
+file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/glslang/glslang/Include/InfoSink.h ${output_info_sink_h})
 
 foreach(arch_item ${ARCH_LIST})
   set(target_generator $ENV{NANOEM_TARGET_GENERATOR})

--- a/scripts/build.cmake
+++ b/scripts/build.cmake
@@ -627,7 +627,7 @@ find_package(Git REQUIRED)
 execute_process(COMMAND ${GIT_EXECUTABLE} checkout -- .
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/bullet3
                 RESULT_VARIABLE result)
-execute_process(COMMAND ${GIT_EXECUTABLE} apply ${CMAKE_CURRENT_SOURCE_DIR}/cmake/bullet-2.76.diff
+execute_process(COMMAND ${GIT_EXECUTABLE} apply --ignore-space-change ${CMAKE_CURRENT_SOURCE_DIR}/cmake/bullet-2.76.diff
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/bullet3
                 RESULT_VARIABLE result)
 execute_process(COMMAND ${GIT_EXECUTABLE} checkout -- .


### PR DESCRIPTION
## Summary

This PR revises build flow for #23 and #25 as the title describes

## Details

This PR implementation consists below changes.

* submodule checkout command typo (#23 )
* prefer to use `git apply` instead of GnuWin's `patch` command (#25)
  * remove unnecessary `GIT_FOUND` condition
* change `build` to `out` directory
  * includes `.gitignore` revision

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
