### PR TITLE
[emapp] more video encoder fixes

### DIFF
--- a/emapp/include/emapp/internal/CapturingPassState.h
+++ b/emapp/include/emapp/internal/CapturingPassState.h
@@ -97,7 +97,8 @@ protected:
 
     StateController *stateController();
     const ByteArray &frameImageData() const;
-    nanoem_u8_t *frameImageDataPtr();
+    nanoem_u8_t *mutableFrameImageDataPtr();
+    bx::Mutex &mutex();
     sg_image_desc outputImageDescription() const;
     StateTransition stateTransition();
     void setStateTransition(StateTransition value);

--- a/emapp/plugins/lsmash/lsmash.cc
+++ b/emapp/plugins/lsmash/lsmash.cc
@@ -397,7 +397,11 @@ struct LSmashEncoder {
     {
         int result = 0;
         if (m_root) {
-            m_worker->waitForCompletion();
+            if (m_worker) {
+                m_worker->waitForCompletion();
+                delete m_worker;
+                m_worker = nullptr;
+            }
             result = lsmash_close_file(&m_fileParameters);
             handleStatusCode(result, status);
             lsmash_cleanup_summary(reinterpret_cast<lsmash_summary_t *>(m_audioSummary));


### PR DESCRIPTION
## Summary

This PR applies more fixes around video encoder.

## Details

The PR implementation contains below fixes.

* Fixes an issue of thread leak in `plugin_lsmash` detected by TSAN
* Private class `AsyncReadHandler` now works as serial using mutex

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
