### PR TITLE
[emapp] fixed a validation error of MSAA with effect

### DIFF
--- a/emapp/include/emapp/Effect.h
+++ b/emapp/include/emapp/Effect.h
@@ -122,6 +122,7 @@ public:
     void destroyAllDrawableRenderTargetColorImages(const IDrawable *drawable);
     void generateRenderTargetMipmapImagesChain();
     void generateOffscreenMipmapImagesChain(const effect::OffscreenRenderTargetOption &option);
+    void updateCurrentRenderTargetPixelFormatSampleCount();
     void destroy();
 
     const effect::RenderTargetColorImageContainer *findRenderTargetImageContainer(

--- a/emapp/include/emapp/PixelFormat.h
+++ b/emapp/include/emapp/PixelFormat.h
@@ -14,15 +14,28 @@
 
 namespace nanoem {
 
-struct PixelFormat {
-    PixelFormat();
-    PixelFormat(const PixelFormat &value);
-    ~PixelFormat();
+class PixelFormat NANOEM_DECL_SEALED : private NonCopyable {
+public:
+    PixelFormat() NANOEM_DECL_NOEXCEPT;
+    PixelFormat(const PixelFormat &value) NANOEM_DECL_NOEXCEPT;
+    ~PixelFormat() NANOEM_DECL_NOEXCEPT;
 
-    nanoem_u32_t hash() const;
+    nanoem_u32_t hash() const NANOEM_DECL_NOEXCEPT;
     void addHash(bx::HashMurmur2A &value) const;
-    void reset();
+    void reset(int numSamples);
 
+    sg_pixel_format colorPixelFormat(nanoem_rsize_t offset) const NANOEM_DECL_NOEXCEPT;
+    void setColorPixelFormat(sg_pixel_format value, nanoem_rsize_t offset);
+    sg_pixel_format depthPixelFormat() const NANOEM_DECL_NOEXCEPT;
+    void setDepthPixelFormat(sg_pixel_format value);
+    int numColorAttachments() const NANOEM_DECL_NOEXCEPT;
+    void setNumColorAttachemnts(int value);
+    int numSamples() const NANOEM_DECL_NOEXCEPT;
+    void setNumSamples(int value);
+
+    void operator=(const PixelFormat &value) NANOEM_DECL_NOEXCEPT;
+
+private:
     sg_pixel_format m_colorPixelFormats[SG_MAX_COLOR_ATTACHMENTS];
     sg_pixel_format m_depthPixelFormat;
     int m_numColorAttachments;

--- a/emapp/include/emapp/Project.h
+++ b/emapp/include/emapp/Project.h
@@ -378,7 +378,6 @@ public:
     void blitRenderPass(sg::PassBlock::IDrawQueue *drawQueue, sg_pass destRenderPass, sg_pass sourceRenderPass);
     void clearRenderPass(
         sg::PassBlock::IDrawQueue *drawQueue, sg_pass pass, const sg_pass_action &action, const PixelFormat &format);
-    PixelFormat findRenderPassPixelFormat(sg_pass value) const NANOEM_DECL_NOEXCEPT;
     PixelFormat findRenderPassPixelFormat(sg_pass value, int sampleCount) const NANOEM_DECL_NOEXCEPT;
     PixelFormat currentRenderPassPixelFormat() const NANOEM_DECL_NOEXCEPT;
     const char *findRenderPassName(sg_pass value) const NANOEM_DECL_NOEXCEPT;

--- a/emapp/include/emapp/effect/Common.h
+++ b/emapp/include/emapp/effect/Common.h
@@ -16,8 +16,8 @@
 namespace nanoem {
 
 class Effect;
+class PixelFormat;
 struct APNGImage;
-struct PixelFormat;
 
 namespace internal {
 class BlitPass;

--- a/emapp/include/emapp/internal/BasePass.h
+++ b/emapp/include/emapp/internal/BasePass.h
@@ -12,7 +12,7 @@
 
 namespace nanoem {
 
-struct PixelFormat;
+class PixelFormat;
 class Project;
 
 namespace internal {

--- a/emapp/include/emapp/internal/project/Track.h
+++ b/emapp/include/emapp/internal/project/Track.h
@@ -56,7 +56,7 @@ class LightTrack NANOEM_DECL_SEALED : public BaseTrack {
 public:
     LightTrack(DirectionalLight *light);
     ~LightTrack() NANOEM_DECL_NOEXCEPT;
-    ;
+
     Type type() const NANOEM_DECL_NOEXCEPT_OVERRIDE;
     const void *opaque() const NANOEM_DECL_NOEXCEPT_OVERRIDE;
     void *opaque() NANOEM_DECL_NOEXCEPT_OVERRIDE;

--- a/emapp/src/AccessoryProgramBundle.cc
+++ b/emapp/src/AccessoryProgramBundle.cc
@@ -309,7 +309,7 @@ AccessoryProgramBundle::CommonPass::execute(const IDrawable * /* drawable */, co
                isOffscreenRenderPassActive = project->isOffscreenRenderPassActive();
     const sg_pass pass =
         isOffscreenRenderPassActive ? project->currentOffscreenRenderPass() : project->currentRenderPass();
-    const PixelFormat &format = project->findRenderPassPixelFormat(pass);
+    const PixelFormat format(project->findRenderPassPixelFormat(pass, project->sampleCount()));
     const TechniqueType techniqueType = m_parentTechnique->techniqueType();
     bx::HashMurmur2A hash;
     hash.begin();
@@ -330,12 +330,12 @@ AccessoryProgramBundle::CommonPass::execute(const IDrawable * /* drawable */, co
         Inline::clearZeroMemory(desc);
         Accessory::setStandardPipelineDescription(desc);
         desc.shader = m_parentTechnique->shader();
-        desc.color_count = format.m_numColorAttachments;
+        desc.color_count = format.numColorAttachments();
         sg_color_state &cs = desc.colors[0];
-        cs.pixel_format = format.m_colorPixelFormats[0];
+        cs.pixel_format = format.colorPixelFormat(0);
         sg_depth_state &ds = desc.depth;
         ds.compare = isDepthEnabled ? SG_COMPAREFUNC_LESS_EQUAL : SG_COMPAREFUNC_ALWAYS;
-        ds.pixel_format = format.m_depthPixelFormat;
+        ds.pixel_format = format.depthPixelFormat();
         ds.write_enabled = isDepthEnabled;
         if (isAddBlend) {
             Project::setAddBlendMode(cs);
@@ -350,7 +350,7 @@ AccessoryProgramBundle::CommonPass::execute(const IDrawable * /* drawable */, co
             Project::setShadowDepthStencilState(desc.depth, desc.stencil);
         }
         desc.cull_mode = m_cullMode;
-        desc.sample_count = format.m_numSamples;
+        desc.sample_count = format.numSamples();
         char label[Inline::kMarkerStringLength];
         if (Inline::isDebugLabelEnabled()) {
             StringUtils::format(

--- a/emapp/src/ModelProgramBundle.cc
+++ b/emapp/src/ModelProgramBundle.cc
@@ -384,7 +384,7 @@ ModelProgramBundle::CommonPass::execute(const IDrawable * /* drawable */, const 
                isOffscreenRenderPassActive = project->isOffscreenRenderPassActive();
     const sg_pass pass =
         isOffscreenRenderPassActive ? project->currentOffscreenRenderPass() : project->currentRenderPass();
-    const PixelFormat &format = project->findRenderPassPixelFormat(pass);
+    const PixelFormat format(project->findRenderPassPixelFormat(pass, project->sampleCount()));
     const TechniqueType techniqueType = m_parentTechnique->techniqueType();
     bx::HashMurmur2A hash;
     hash.begin();
@@ -412,12 +412,12 @@ ModelProgramBundle::CommonPass::execute(const IDrawable * /* drawable */, const 
         }
         desc.shader = m_parentTechnique->shader();
         desc.primitive_type = m_primitiveType;
-        desc.color_count = format.m_numColorAttachments;
+        desc.color_count = format.numColorAttachments();
         sg_color_state &cs = desc.colors[0];
-        cs.pixel_format = format.m_colorPixelFormats[0];
+        cs.pixel_format = format.colorPixelFormat(0);
         sg_depth_state &ds = desc.depth;
         ds.compare = isDepthEnabled ? SG_COMPAREFUNC_LESS_EQUAL : SG_COMPAREFUNC_ALWAYS;
-        ds.pixel_format = format.m_depthPixelFormat;
+        ds.pixel_format = format.depthPixelFormat();
         ds.write_enabled = isDepthEnabled;
         if (isAddBlend) {
             Project::setAddBlendMode(cs);
@@ -432,7 +432,7 @@ ModelProgramBundle::CommonPass::execute(const IDrawable * /* drawable */, const 
             Project::setShadowDepthStencilState(desc.depth, desc.stencil);
         }
         desc.cull_mode = m_cullMode;
-        desc.sample_count = format.m_numSamples;
+        desc.sample_count = format.numSamples();
         char label[Inline::kMarkerStringLength];
         if (Inline::isDebugLabelEnabled()) {
             StringUtils::format(

--- a/emapp/src/PixelFormat.cc
+++ b/emapp/src/PixelFormat.cc
@@ -10,15 +10,15 @@
 
 namespace nanoem {
 
-PixelFormat::PixelFormat()
-    : m_depthPixelFormat(SG_PIXELFORMAT_DEPTH_STENCIL)
+PixelFormat::PixelFormat() NANOEM_DECL_NOEXCEPT
+    : m_depthPixelFormat(_SG_PIXELFORMAT_DEFAULT)
     , m_numColorAttachments(1)
     , m_numSamples(1)
 {
     Inline::clearZeroMemory(m_colorPixelFormats);
 }
 
-PixelFormat::PixelFormat(const PixelFormat &value)
+PixelFormat::PixelFormat(const PixelFormat &value) NANOEM_DECL_NOEXCEPT
     : m_depthPixelFormat(value.m_depthPixelFormat)
     , m_numColorAttachments(value.m_numColorAttachments)
     , m_numSamples(value.m_numSamples)
@@ -26,12 +26,12 @@ PixelFormat::PixelFormat(const PixelFormat &value)
     memcpy(m_colorPixelFormats, value.m_colorPixelFormats, sizeof(m_colorPixelFormats));
 }
 
-PixelFormat::~PixelFormat()
+PixelFormat::~PixelFormat() NANOEM_DECL_NOEXCEPT
 {
 }
 
 nanoem_u32_t
-PixelFormat::hash() const
+PixelFormat::hash() const NANOEM_DECL_NOEXCEPT
 {
     bx::HashMurmur2A v;
     v.begin();
@@ -49,14 +49,73 @@ PixelFormat::addHash(bx::HashMurmur2A &value) const
 }
 
 void
-PixelFormat::reset()
+PixelFormat::reset(int numSamples)
 {
     for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
         m_colorPixelFormats[i] = _SG_PIXELFORMAT_DEFAULT;
     }
     m_depthPixelFormat = _SG_PIXELFORMAT_DEFAULT;
     m_numColorAttachments = 1;
-    m_numSamples = 1;
+    m_numSamples = numSamples;
+}
+
+sg_pixel_format
+PixelFormat::colorPixelFormat(nanoem_rsize_t offset) const NANOEM_DECL_NOEXCEPT
+{
+    return offset < SG_MAX_COLOR_ATTACHMENTS ? m_colorPixelFormats[offset] : SG_PIXELFORMAT_NONE;
+}
+
+void
+PixelFormat::setColorPixelFormat(sg_pixel_format value, nanoem_rsize_t offset)
+{
+    if (offset < SG_MAX_COLOR_ATTACHMENTS) {
+        m_colorPixelFormats[offset] = value;
+    }
+}
+
+sg_pixel_format
+PixelFormat::depthPixelFormat() const NANOEM_DECL_NOEXCEPT
+{
+    return m_depthPixelFormat;
+}
+
+void
+PixelFormat::setDepthPixelFormat(sg_pixel_format value)
+{
+    m_depthPixelFormat = value;
+}
+
+int
+PixelFormat::numColorAttachments() const NANOEM_DECL_NOEXCEPT
+{
+    return m_numColorAttachments;
+}
+
+void
+PixelFormat::setNumColorAttachemnts(int value)
+{
+    m_numColorAttachments = glm::clamp(value, 1, int(SG_MAX_COLOR_ATTACHMENTS));
+}
+
+int
+PixelFormat::numSamples() const NANOEM_DECL_NOEXCEPT
+{
+    return m_numSamples;
+}
+
+void
+PixelFormat::setNumSamples(int value)
+{
+    m_numSamples = glm::max(value, 1);
+}
+
+void
+PixelFormat::operator=(const PixelFormat &value) NANOEM_DECL_NOEXCEPT
+{
+    memcpy(m_colorPixelFormats, value.m_colorPixelFormats, sizeof(m_colorPixelFormats));
+    m_depthPixelFormat = value.m_depthPixelFormat;
+    m_numColorAttachments = value.m_numColorAttachments;
+    m_numSamples = value.m_numSamples;
 }
 
 } /* namespace nanoem */

--- a/emapp/src/ShadowCamera.cc
+++ b/emapp/src/ShadowCamera.cc
@@ -122,9 +122,10 @@ ShadowCamera::update()
         Inline::clearZeroMemory(id);
         id.width = m_textureSize.x;
         id.height = m_textureSize.y;
-        id.pixel_format = format.m_colorPixelFormats[0] = SG_PIXELFORMAT_R32F;
+        id.pixel_format = SG_PIXELFORMAT_R32F;
         id.mag_filter = id.min_filter = SG_FILTER_NEAREST;
         id.render_target = true;
+        format.setColorPixelFormat(SG_PIXELFORMAT_R32F, 0);
         sg_image &colorImage = m_shadowPassDesc.color_attachments[0].image;
         sg::destroy_image(colorImage);
         if (Inline::isDebugLabelEnabled()) {
@@ -133,7 +134,8 @@ ShadowCamera::update()
         colorImage = sg::make_image(&id);
         nanoem_assert(sg::query_image_state(colorImage) == SG_RESOURCESTATE_VALID, "color image must be valid");
         SG_LABEL_IMAGE(colorImage, kColorImageName);
-        id.pixel_format = format.m_depthPixelFormat = SG_PIXELFORMAT_DEPTH_STENCIL;
+        id.pixel_format = SG_PIXELFORMAT_DEPTH_STENCIL;
+        format.setDepthPixelFormat(SG_PIXELFORMAT_DEPTH_STENCIL);
         sg_image &depthImage = m_shadowPassDesc.depth_stencil_attachment.image;
         sg::destroy_image(depthImage);
         if (Inline::isDebugLabelEnabled()) {
@@ -143,8 +145,8 @@ ShadowCamera::update()
         nanoem_assert(sg::query_image_state(depthImage) == SG_RESOURCESTATE_VALID, "color image must be valid");
         SG_LABEL_IMAGE(depthImage, kDepthImageName);
         sg::destroy_pass(m_shadowPass);
-        format.m_numColorAttachments = 1;
-        format.m_numSamples = 0;
+        format.setNumColorAttachemnts(1);
+        format.setNumSamples(1);
         m_shadowPass = m_project->registerRenderPass(m_shadowPassDesc, format);
         m_project->setRenderPassName(m_shadowPass, kPassName);
         SG_POP_GROUP();

--- a/emapp/src/effect/EffectCommon.cc
+++ b/emapp/src/effect/EffectCommon.cc
@@ -1077,7 +1077,7 @@ RenderPassScope::modifyPipelineDescription(sg_pipeline_desc &pd) const NANOEM_DE
 {
     if (m_normalizer) {
         const PixelFormat format(m_normalizer->normalizedColorImagePixelFormat());
-        pd.colors[0].pixel_format = format.m_colorPixelFormats[0];
+        pd.colors[0].pixel_format = format.colorPixelFormat(0);
     }
 }
 

--- a/emapp/src/effect/RenderTargetNormalizer.cc
+++ b/emapp/src/effect/RenderTargetNormalizer.cc
@@ -68,7 +68,7 @@ RenderTargetNormalizer::normalize(const IDrawable *drawable, const Pass *passPtr
                 const sg_pixel_format colorImageFormat = containerPtr->colorImageDescription().pixel_format;
                 PixelFormat pixelFormat(preferredPixelFormat);
                 if (i > 0) {
-                    pixelFormat.m_colorPixelFormats[0] = colorImageFormat;
+                    pixelFormat.setColorPixelFormat(colorImageFormat, 0);
                 }
                 if (normalizedColorFormat != colorImageFormat) {
                     normalizeRenderTargetColorImage(containerPtr, pixelFormat, originPassDescription, i,
@@ -90,7 +90,7 @@ RenderTargetNormalizer::read()
     PixelFormat format(m_normalizedColorImageFormat);
     internal::BlitPass *blitter = m_effect->project()->sharedImageBlitter();
     sg::PassBlock::IDrawQueue *drawQueue = m_effect->project()->sharedBatchDrawQueue();
-    format.m_numColorAttachments = 1;
+    format.setNumColorAttachemnts(1);
     for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
         const sg::NamedImage &source = m_originColorImageRefs[i];
         if (sg::is_valid(source.first)) {
@@ -106,12 +106,12 @@ RenderTargetNormalizer::apply(
 {
     PipelineDescriptor dest(pass->pipelineDescriptor());
     pass->technique()->overrideObjectPipelineDescription(drawable, dest);
-    dest.m_body.color_count = m_normalizedColorImageFormat.m_numColorAttachments;
-    dest.m_body.colors[0].pixel_format = m_normalizedColorImageFormat.m_colorPixelFormats[0];
+    dest.m_body.color_count = m_normalizedColorImageFormat.numColorAttachments();
+    dest.m_body.colors[0].pixel_format = m_normalizedColorImageFormat.colorPixelFormat(0);
     sg_pipeline pipeline = pass->registerPipelineSet(dest.m_body);
     pb.applyPipelineBindings(pipeline, bindings);
     SG_INSERT_MARKERF("effect::RenderTargetNormalizer::apply(pipeline=%d, format=%d)", pipeline.id,
-        m_normalizedColorImageFormat.m_colorPixelFormats);
+        m_normalizedColorImageFormat.colorPixelFormat(0));
 }
 
 void
@@ -265,7 +265,7 @@ RenderTargetNormalizer::createNormalizePass(const char *name, const PixelFormat 
     }
     PixelFormat &format = m_originColorImageFormats[index];
     format = originFormat;
-    format.m_numColorAttachments = 1;
+    format.setNumColorAttachemnts(1);
     SG_POP_GROUP();
 }
 

--- a/emapp/src/effect/Technique.cc
+++ b/emapp/src/effect/Technique.cc
@@ -320,6 +320,7 @@ Technique::execute(const IDrawable *drawable, bool scriptExternalColor)
                     char nameBuffer[Inline::kMarkerStringLength];
                     StringUtils::format(nameBuffer, sizeof(nameBuffer), "%s/%s/ScriptExternalColor",
                         m_effect->nameConstString(), nameConstString());
+                    m_effect->updateCurrentRenderTargetPixelFormatSampleCount();
                     m_scriptExternalColor.save(drawable, nameBuffer);
                     m_offsets.second = scriptIndex + 1;
                     break;

--- a/emapp/src/internal/BasePass.cc
+++ b/emapp/src/internal/BasePass.cc
@@ -44,7 +44,7 @@ BasePass::destroy() NANOEM_DECL_NOEXCEPT
 void
 BasePass::setupPipeline(const PixelFormat &format, sg_pipeline &pipelineRef)
 {
-    nanoem_u32_t key = format.hash();
+    const nanoem_u32_t key = format.hash();
     PipelineMap::const_iterator it = m_pipelines.find(key);
     if (it != m_pipelines.end()) {
         pipelineRef = it->second;
@@ -64,12 +64,12 @@ BasePass::setupPipeline(const PixelFormat &format, sg_pipeline &pipelineRef)
         sg_pipeline_desc pd;
         Inline::clearZeroMemory(pd);
         setupPipelineDescription(pd);
-        pd.color_count = format.m_numColorAttachments;
+        pd.color_count = format.numColorAttachments();
         for (int i = 0, numColorAttachments = pd.color_count; i < numColorAttachments; i++) {
-            pd.colors[i].pixel_format = format.m_colorPixelFormats[i];
+            pd.colors[i].pixel_format = format.colorPixelFormat(i);
         }
-        pd.depth.pixel_format = format.m_depthPixelFormat;
-        pd.sample_count = format.m_numSamples;
+        pd.depth.pixel_format = format.depthPixelFormat();
+        pd.sample_count = format.numSamples();
         pd.shader = m_shader;
         char label[Inline::kMarkerStringLength];
         if (Inline::isDebugLabelEnabled()) {

--- a/emapp/src/internal/CapturingPassState.cc
+++ b/emapp/src/internal/CapturingPassState.cc
@@ -170,10 +170,10 @@ CapturingPassState::ImageBlitter::blit(sg_pass pass)
 {
     sg_pipeline pipeline = { SG_INVALID_ID };
     PixelFormat format;
-    format.m_numSamples = 1;
-    format.m_colorPixelFormats[0] = SG_PIXELFORMAT_RGBA8;
-    format.m_depthPixelFormat = SG_PIXELFORMAT_DEPTH_STENCIL;
-    format.m_numColorAttachments = 1;
+    format.setNumSamples(1);
+    format.setColorPixelFormat(SG_PIXELFORMAT_RGBA8, 0);
+    format.setDepthPixelFormat(SG_PIXELFORMAT_DEPTH_STENCIL);
+    format.setNumColorAttachemnts(1);
     setupPipeline(format, pipeline);
     draw(pipeline, pass, m_project->viewportPrimaryImage());
 }

--- a/emapp/src/internal/DecoderPluginBasedBackgroundVideoRenderer.cc
+++ b/emapp/src/internal/DecoderPluginBasedBackgroundVideoRenderer.cc
@@ -88,7 +88,7 @@ DecoderPluginBasedBackgroundVideoRenderer::draw(
             m_blitter->markAsDirty();
             m_lastRect = rect;
         }
-        const PixelFormat format(project->findRenderPassPixelFormat(pass));
+        const PixelFormat format(project->findRenderPassPixelFormat(pass, project->sampleCount()));
         m_blitter->blit(project->sharedBatchDrawQueue(), namedPass, namedImage, rect, format);
     }
 }

--- a/emapp/src/internal/LineDrawer.cc
+++ b/emapp/src/internal/LineDrawer.cc
@@ -139,9 +139,9 @@ LineDrawer::draw(sg::PassBlock &pb, const Option &option)
         sg_pipeline_desc pd;
         Inline::clearZeroMemory(pd);
         pd.shader = option.m_primitiveType == SG_PRIMITIVETYPE_POINTS ? m_pointedShader : m_shader;
-        pd.colors[0].pixel_format = format.m_colorPixelFormats[0];
-        pd.depth.pixel_format = format.m_depthPixelFormat;
-        pd.color_count = format.m_numColorAttachments;
+        pd.colors[0].pixel_format = format.colorPixelFormat(0);
+        pd.depth.pixel_format = format.depthPixelFormat();
+        pd.color_count = format.numColorAttachments();
         if (option.m_enableBlendMode) {
             Project::setAlphaBlendMode(pd.colors[0]);
         }
@@ -149,7 +149,7 @@ LineDrawer::draw(sg::PassBlock &pb, const Option &option)
             pd.depth.write_enabled = true;
             pd.depth.compare = SG_COMPAREFUNC_LESS_EQUAL;
         }
-        pd.sample_count = format.m_numSamples;
+        pd.sample_count = format.numSamples();
         sg_layout_desc &ld = pd.layout;
         ld.buffers[0].stride = sizeof(sg::LineVertexUnit);
         ld.attrs[0] = sg_vertex_attr_desc { 0, offsetof(sg::LineVertexUnit, m_position), SG_VERTEXFORMAT_FLOAT3 };

--- a/macos/classes/BaseVideoRecorder.mm
+++ b/macos/classes/BaseVideoRecorder.mm
@@ -468,7 +468,7 @@ BaseVideoRecorder::blitPass(sg::PassBlock::IDrawQueue *drawQueue, sg_pass value)
 {
     static const char *kSourceImageName = "IOSurfaceRef";
     PixelFormat format;
-    format.m_colorPixelFormats[0] = pixelFormat();
+    format.setColorPixelFormat(pixelFormat(), 0);
     sg_image viewportImage = m_project->viewportPrimaryImage();
     uint32_t sampleCount = m_project->sampleCount();
     if (sampleCount > 1) {

--- a/macos/classes/MetalBackgroundRenderer.mm
+++ b/macos/classes/MetalBackgroundRenderer.mm
@@ -54,7 +54,7 @@ MetalBackgroundRenderer::draw(sg_pass pass, const Vector4 &rect, Project *projec
     }
     const sg::NamedPass namedPass(tinystl::make_pair(pass, Project::kViewportPrimaryName));
     const sg::NamedImage namedImage(tinystl::make_pair(m_imageHandle, kLabelPrefix));
-    const PixelFormat format(project->findRenderPassPixelFormat(pass));
+    const PixelFormat format(project->findRenderPassPixelFormat(pass, project->sampleCount()));
     blitter->blit(project->sharedBatchDrawQueue(), namedPass, namedImage, rect, format);
     SG_POP_GROUP();
 }

--- a/win32/src/D3D11BackgroundDrawer.cc
+++ b/win32/src/D3D11BackgroundDrawer.cc
@@ -136,7 +136,7 @@ D3D11BackgroundVideoDrawer::draw(sg_pass pass, const Vector4 &rect, nanoem_f32_t
     if (m_reader && sg::is_valid(m_image)) {
         const sg::NamedPass namedPass(tinystl::make_pair(pass, Project::kViewportPrimaryName));
         const sg::NamedImage namedImage(tinystl::make_pair(m_image, kLabelPrefix));
-        const PixelFormat format(project->findRenderPassPixelFormat(pass));
+        const PixelFormat format(project->findRenderPassPixelFormat(pass, project->sampleCount()));
         project->sharedImageBlitter()->blit(project->sharedBatchDrawQueue(), namedPass, namedImage, rect, format);
         if (!m_durationUpdated) {
             PROPVARIANT pd;

--- a/win32/src/D3D11VideoRecorder.cc
+++ b/win32/src/D3D11VideoRecorder.cc
@@ -478,7 +478,7 @@ D3D11VideoRecorder::blitPass(sg::PassBlock::IDrawQueue *drawQueue, sg_pass value
     const sg_image viewportImage = m_project->viewportPrimaryImage();
     const int sampleCount = m_project->sampleCount();
     PixelFormat format;
-    format.m_colorPixelFormats[0] = m_colorImageDescription.pixel_format;
+    format.setColorPixelFormat(m_colorImageDescription.pixel_format, 0);
     if (sampleCount > 1) {
         m_blitterMSAA->blit(drawQueue, tinystl::make_pair(m_receiveMSAAPass, kLabelPrefixName),
             tinystl::make_pair(viewportImage, Project::kViewportPrimaryName), kRect, format);


### PR DESCRIPTION
## Summary

This PR fixed a validation error of MSAA with effect due to unmatched MSAA count at `PixelFormat::reset` and script external initialization.

## Details

The PR implementation includes following changes.

* changes all members of `PixelFormat` to get/set property methods
* adds numSamples argument of `PixelFormat::reset` to fix the issue as the PR describes
* adds `Effect::updateCurrentRenderTargetPixelFormatSampleCount` to force updating sample count at script external initialization

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
