### PR TITLE
[emapp] trim compiler warnings

### DIFF
--- a/dependencies/fx9/src/Compiler.cc
+++ b/dependencies/fx9/src/Compiler.cc
@@ -650,7 +650,7 @@ Compiler::BaseParameterConverter::fillParameterValues(const ParserContext::NodeI
                     parameterPtr->value.data =
                         static_cast<uint8_t *>(m_parent->m_allocator->allocate(parameterPtr->value.len));
                 }
-                else if (value->m_type->isVector() && value->m_type->getVectorSize() == sequence.size()) {
+                else if (value->m_type->isVector() && size_t(value->m_type->getVectorSize()) == sequence.size()) {
                     size_t numComponents = sequence.size();
                     parameterPtr->value.len = 16;
                     parameterPtr->value.data =
@@ -697,7 +697,6 @@ Compiler::BaseParameterConverter::fillParameterValues(const ParserContext::NodeI
                 }
             }
             else if (const TIntermConstantUnion *constantUnionNode = initializerNode->getAsConstantUnion()) {
-                const TConstUnionArray &values = constantUnionNode->getConstArray();
                 parameterPtr->value.len = 16;
                 parameterPtr->value.data =
                     static_cast<uint8_t *>(m_parent->m_allocator->allocate(parameterPtr->value.len));

--- a/emapp/bundle/sokol/sokol_metal_common.m
+++ b/emapp/bundle/sokol/sokol_metal_common.m
@@ -151,7 +151,7 @@ sgx_push_group(const char *text)
 }
 
 SGX_API_DECL void
-sgx_pop_group()
+sgx_pop_group(void)
 {
     if (@available(macOS 10.13, *)) {
         if (_sg.mtl.cmd_buffer) {
@@ -264,7 +264,7 @@ sgx_insert_marker(const char *text)
 }
 
 SGX_API_DECL void *
-sgx_mtl_cmd_queue()
+sgx_mtl_cmd_queue(void)
 {
     return (__bridge void *) _sg.mtl.cmd_queue;
 }

--- a/emapp/src/BaseApplicationService.cc
+++ b/emapp/src/BaseApplicationService.cc
@@ -2596,7 +2596,7 @@ BaseApplicationService::defaultPassPixelFormat() const NANOEM_DECL_NOEXCEPT
 
 void
 BaseApplicationService::beginDefaultPass(
-    nanoem_u32_t /* windowID */, const sg_pass_action &pa, int width, int height, int &sampleCount)
+    nanoem_u32_t /* windowID */, const sg_pass_action &pa, int width, int height, int & /* sampleCount */)
 {
     sg::begin_default_pass(&pa, width, height);
 }

--- a/emapp/src/command/ModelObjectCommand.cc
+++ b/emapp/src/command/ModelObjectCommand.cc
@@ -5292,11 +5292,13 @@ BatchChangeAllSoftBodyObjectsCommand::create(Model *activeModel, const List &obj
 void
 BatchChangeAllSoftBodyObjectsCommand::save(const nanoem_model_soft_body_t *softBodyPtr, Parameter &parameter)
 {
+    BX_UNUSED_2(softBodyPtr, parameter);
 }
 
 void
 BatchChangeAllSoftBodyObjectsCommand::restore(const Parameter &parameter, nanoem_mutable_model_soft_body_t *softBodyPtr)
 {
+    BX_UNUSED_2(parameter, softBodyPtr);
 }
 
 BatchChangeAllSoftBodyObjectsCommand::BatchChangeAllSoftBodyObjectsCommand(

--- a/emapp/src/internal/ImGuiApplicationMenuBuilder.cc
+++ b/emapp/src/internal/ImGuiApplicationMenuBuilder.cc
@@ -70,7 +70,7 @@ IGFD_OpenDialog(ImGuiFileDialog *vContext, const char *vKey, const char *vTitle,
     const char *vPath, const char *vFileName, const int vCountSelectionMax, void *vUserDatas,
     ImGuiFileDialogFlags vFlags)
 {
-    BX_UNUSED_8(vContext, vKey, vTitle, vFilters, vFileName, vCountSelectionMax, vUserDatas, vFlags);
+    BX_UNUSED_9(vContext, vKey, vTitle, vFilters, vPath, vFileName, vCountSelectionMax, vUserDatas, vFlags);
 }
 IMGUIFILEDIALOG_API void
 IGFD_CloseDialog(ImGuiFileDialog *vContext)

--- a/emapp/src/internal/imgui/EffectParameterDialog.cc
+++ b/emapp/src/internal/imgui/EffectParameterDialog.cc
@@ -248,7 +248,7 @@ EffectParameterDialog::layoutAllOffscreenRenderTargetAttachments(Project *projec
     }
     addSeparator();
     const ImTextureID textureID = reinterpret_cast<ImTextureID>(option.m_colorImage.id);
-    if (ImGui::TreeNode(textureID, tr("nanoem.gui.window.project.effect.offscreen.display-texture"))) {
+    if (ImGui::TreeNode(textureID, "%s", tr("nanoem.gui.window.project.effect.offscreen.display-texture"))) {
         ImGui::Image(textureID, calcExpandedImageSize(option.m_colorImageDescription, 1.0f), ImVec2(0, 0), ImVec2(1, 1),
             ImVec4(1, 1, 1, 1), ImGui::ColorConvertU32ToFloat4(ImGuiWindow::kColorBorder));
         ImGui::TreePop();
@@ -377,7 +377,8 @@ EffectParameterDialog::layoutAllModelMaterialEffectAttachments(Project *project)
     if (ImGuiWindow::handleButton(tr("nanoem.gui.window.project.effect.emd.load"),
             ImGui::GetContentRegionAvail().x * 0.5f, isModelSelected)) {
         Model *model = models->data()[m_activeModelTargetIndex];
-        const IFileManager::QueryFileDialogCallbacks callbacks = { model, handleLoadingModelEffectSetting, nullptr };
+        const IFileManager::QueryFileDialogCallbacks callbacks = { model, handleLoadingModelEffectSetting, nullptr,
+            nullptr };
         project->fileManager()->setTransientQueryFileDialogCallback(callbacks);
         StringList extensions;
         extensions.push_back("emd");
@@ -388,7 +389,8 @@ EffectParameterDialog::layoutAllModelMaterialEffectAttachments(Project *project)
     if (ImGuiWindow::handleButton(
             tr("nanoem.gui.window.project.effect.emd.save"), ImGui::GetContentRegionAvail().x, isModelSelected)) {
         Model *model = models->data()[m_activeModelTargetIndex];
-        const IFileManager::QueryFileDialogCallbacks callbacks = { model, handleSaveingModelEffectSetting, nullptr };
+        const IFileManager::QueryFileDialogCallbacks callbacks = { model, handleSaveingModelEffectSetting, nullptr,
+            nullptr };
         project->fileManager()->setTransientQueryFileDialogCallback(callbacks);
         StringList extensions;
         extensions.push_back("emd");

--- a/emapp/src/model/Constraint.cc
+++ b/emapp/src/model/Constraint.cc
@@ -242,7 +242,7 @@ Constraint::destroy(void *opaque, nanoem_model_object_t * /* constraintPtr */) N
     nanoem_delete(self);
 }
 
-Constraint::Constraint(const PlaceHolder & /* holder */) NANOEM_DECL_NOEXCEPT : m_states(kPrivateStateEnabled)
+Constraint::Constraint(const PlaceHolder & /* holder */) NANOEM_DECL_NOEXCEPT : m_states(kPrivateStateInitialValue)
 {
 }
 

--- a/nanoem/ext/document.c
+++ b/nanoem/ext/document.c
@@ -4005,8 +4005,8 @@ nanoemMutableDocumentSelfShadowKeyframeSetMode(nanoem_mutable_document_self_shad
     }
 }
 
-nanoem_document_base_keyframe_t* APIENTRY
-nanoemMutableDocumentSelfShadowKeyframeGetOrigin(nanoem_mutable_document_self_shadow_keyframe_t* keyframe)
+nanoem_document_self_shadow_keyframe_t *APIENTRY
+nanoemMutableDocumentSelfShadowKeyframeGetOrigin(nanoem_mutable_document_self_shadow_keyframe_t *keyframe)
 {
     return nanoem_is_not_null(keyframe) ? keyframe->origin : NULL;
 }

--- a/nanoem/ext/document.h
+++ b/nanoem/ext/document.h
@@ -2308,7 +2308,7 @@ nanoemMutableDocumentSelfShadowKeyframeSetMode(nanoem_mutable_document_self_shad
  *
  * \param model The opaque document gravity keyframe object
  */
-NANOEM_DECL_API nanoem_document_base_keyframe_t *APIENTRY
+NANOEM_DECL_API nanoem_document_self_shadow_keyframe_t *APIENTRY
 nanoemMutableDocumentSelfShadowKeyframeGetOrigin(nanoem_mutable_document_self_shadow_keyframe_t *keyframe);
 
 /**


### PR DESCRIPTION
## Summary

> **The PR contains ABI may break due to incorrect return type**

This PR reduces compiler (clang) warnings.

## Details

The PR basically fixes compiler warnings but `nanoemMutableDocumentSelfShadowKeyframeGetOrigin` returns incorrect type so this causes nanoem ABI break when document extension is enabled and the functions is used. Fortunately nanoem/emapp codebase doesn't use the function.

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
