### PR TITLE
[emapp] upgrade ImGuiFileDialog to v0.6.2 and fix misusage

### DIFF
--- a/emapp/include/emapp/internal/ImGuiApplicationMenuBuilder.h
+++ b/emapp/include/emapp/internal/ImGuiApplicationMenuBuilder.h
@@ -111,8 +111,8 @@ private:
 
         void *m_instance;
         StringList m_allowedExtensions;
+        String m_lastOpenDirectoryPath;
         nanoem_u32_t m_type;
-        bool m_opened;
     };
     struct OpenFileDialogState : FileDialogState {
         void execute(const URI &fileURI, BaseApplicationClient *client) NANOEM_DECL_OVERRIDE;

--- a/emapp/src/internal/ImGuiApplicationMenuBuilder.cc
+++ b/emapp/src/internal/ImGuiApplicationMenuBuilder.cc
@@ -53,6 +53,12 @@ IGFD_IsOk(ImGuiFileDialog *vContext)
     BX_UNUSED_1(vContext);
     return false;
 }
+IMGUIFILEDIALOG_API bool
+IGFD_IsOpened(ImGuiFileDialog *vContext)
+{
+    BX_UNUSED_1(vContext);
+    return false;
+}
 IMGUIFILEDIALOG_API char *
 IGFD_GetCurrentFileName(ImGuiFileDialog *vContext)
 {


### PR DESCRIPTION
## Summary

This PR upgrades [ImGuiFileDialog](https://github.com/aiekick/ImGuiFileDialog) to the latest version 0.6.2 (for optional glfw/sapp integration. currently not used in production)

## Details

This PR also fixes mis-usage of `IGFD_GetCurrentPath` and `IGFD_GetCurrentFileName` due to undocumented behavior.

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
