### PR TITLE
[emapp] check camera/project is same as expected before setting value

### DIFF
--- a/emapp/include/emapp/internal/CameraValueState.h
+++ b/emapp/include/emapp/internal/CameraValueState.h
@@ -21,6 +21,9 @@ public:
     BaseCameraVectorValueState(Project *project, ICamera *camera);
     ~BaseCameraVectorValueState();
 
+    const Project *project() const NANOEM_DECL_NOEXCEPT;
+    const ICamera *camera() const NANOEM_DECL_NOEXCEPT;
+
 protected:
     void update();
 

--- a/emapp/include/emapp/internal/ImGuiWindow.h
+++ b/emapp/include/emapp/internal/ImGuiWindow.h
@@ -26,6 +26,7 @@ class AccessoryOpacityValueState;
 class AccessoryOrientationVectorValueState;
 class AccessoryScaleFactorValueState;
 class AccessoryTranslationVectorValueState;
+class BaseCameraVectorValueState;
 class BoneOrientationValueState;
 class BoneTranslationValueState;
 class CameraAngleVectorValueState;
@@ -327,6 +328,8 @@ private:
     static nanoem_rsize_t findTrack(const void *opaque, ITrack::Type targetTrackType, Project::TrackList &tracks);
     static bool isRhombusReactionSelectable(RhombusReactionType type) NANOEM_DECL_NOEXCEPT;
     static bool handleVectorValueState(IVectorValueState *state);
+    static bool validateCameraState(
+        BaseCameraVectorValueState *state, const ICamera *camera, const Project *project) NANOEM_DECL_NOEXCEPT;
     static void appendDrawFlags(
         const Model *activeModel, const imgui::ModelParameterDialog *dialog, nanoem_u32_t &flags) NANOEM_DECL_NOEXCEPT;
 

--- a/emapp/src/internal/CameraValueState.cc
+++ b/emapp/src/internal/CameraValueState.cc
@@ -28,6 +28,18 @@ BaseCameraVectorValueState::~BaseCameraVectorValueState()
     m_camera = 0;
 }
 
+const Project *
+BaseCameraVectorValueState::project() const NANOEM_DECL_NOEXCEPT
+{
+    return m_project;
+}
+
+const ICamera *
+BaseCameraVectorValueState::camera() const NANOEM_DECL_NOEXCEPT
+{
+    return m_camera;
+}
+
 void
 BaseCameraVectorValueState::update()
 {

--- a/emapp/src/internal/ImGuiWindow.cc
+++ b/emapp/src/internal/ImGuiWindow.cc
@@ -2101,6 +2101,13 @@ ImGuiWindow::isRhombusReactionSelectable(RhombusReactionType type) NANOEM_DECL_N
 }
 
 bool
+ImGuiWindow::validateCameraState(
+    BaseCameraVectorValueState *state, const ICamera *camera, const Project *project) NANOEM_DECL_NOEXCEPT
+{
+    return state->camera() == camera && state->project() == project;
+}
+
+bool
 ImGuiWindow::handleVectorValueState(IVectorValueState *state)
 {
     bool deletable = true;
@@ -2257,7 +2264,12 @@ void
 ImGuiWindow::setCameraLookAt(const Vector3 &value, ICamera *camera, Project *project)
 {
     if (m_cameraLookAtVectorValueState) {
-        m_cameraLookAtVectorValueState->setValue(glm::value_ptr(value));
+        if (validateCameraState(m_cameraLookAtVectorValueState, camera, project)) {
+            m_cameraLookAtVectorValueState->setValue(glm::value_ptr(value));
+        }
+        else {
+            nanoem_delete_safe(m_cameraLookAtVectorValueState);
+        }
     }
     else if (camera && project && !project->isPlaying()) {
         m_cameraLookAtVectorValueState = nanoem_new(CameraLookAtVectorValueState(project, camera));
@@ -2268,7 +2280,12 @@ void
 ImGuiWindow::setCameraAngle(const Vector3 &value, ICamera *camera, Project *project)
 {
     if (m_cameraAngleVectorValueState) {
-        m_cameraAngleVectorValueState->setValue(glm::value_ptr(glm::radians(value)));
+        if (validateCameraState(m_cameraAngleVectorValueState, camera, project)) {
+            m_cameraAngleVectorValueState->setValue(glm::value_ptr(glm::radians(value)));
+        }
+        else {
+            nanoem_delete_safe(m_cameraAngleVectorValueState);
+        }
     }
     else if (camera && project && !project->isPlaying()) {
         m_cameraAngleVectorValueState = nanoem_new(CameraAngleVectorValueState(project, camera));
@@ -2279,7 +2296,12 @@ void
 ImGuiWindow::setCameraDistance(nanoem_f32_t value, ICamera *camera, Project *project)
 {
     if (m_cameraDistanceVectorValueState) {
-        m_cameraDistanceVectorValueState->setValue(&value);
+        if (validateCameraState(m_cameraDistanceVectorValueState, camera, project)) {
+            m_cameraDistanceVectorValueState->setValue(&value);
+        }
+        else {
+            nanoem_delete_safe(m_cameraDistanceVectorValueState);
+        }
     }
     else if (camera && project && !project->isPlaying()) {
         m_cameraDistanceVectorValueState = nanoem_new(CameraDistanceVectorValueState(project, camera));
@@ -2290,7 +2312,12 @@ void
 ImGuiWindow::setCameraFov(nanoem_f32_t value, ICamera *camera, Project *project)
 {
     if (m_cameraFovVectorValueState) {
-        m_cameraFovVectorValueState->setValue(&value);
+        if (validateCameraState(m_cameraFovVectorValueState, camera, project)) {
+            m_cameraFovVectorValueState->setValue(&value);
+        }
+        else {
+            nanoem_delete_safe(m_cameraFovVectorValueState);
+        }
     }
     else if (camera && project && !project->isPlaying()) {
         m_cameraFovVectorValueState = nanoem_new(CameraFovVectorValueState(project, camera));


### PR DESCRIPTION
## Summary

This PR checks camera/project is same before setting camera value state.

## Details

`CameraVectorValueState` may differs camera/project reference from construction, this PR checks reference to prevent it.

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
