### PR TITLE
[emapp] prior image loading in effect class with STB

### DIFF
--- a/emapp/include/emapp/ImageLoader.h
+++ b/emapp/include/emapp/ImageLoader.h
@@ -130,6 +130,9 @@ public:
     static void fill1x1BlackPixelImage(sg_image_desc &desc) NANOEM_DECL_NOEXCEPT;
     static void fill1x1TransparentPixelImage(sg_image_desc &desc) NANOEM_DECL_NOEXCEPT;
     static void flipImage(nanoem_u8_t *source, nanoem_u32_t width, nanoem_u32_t height, nanoem_u32_t bpp);
+    static bool decodeImageWithSTB(
+        const nanoem_u8_t *dataPtr, const size_t dataSize, sg_image_desc &desc, nanoem_u8_t **decodedImagePtr);
+    static void releaseDecodedImageWithSTB(nanoem_u8_t **decodedImagePtr);
 
     ImageLoader(const Project *project);
     ~ImageLoader();


### PR DESCRIPTION
## Summary

This PR fixed an unexpected image size detection bug maybe caused by dependencies via bimg.

## Details

(see commit log)

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
