### PR TITLE
[emapp] Add skipping invalid pass to prevent assertion errors

### DIFF
--- a/emapp/src/Project.cc
+++ b/emapp/src/Project.cc
@@ -602,7 +602,13 @@ Project::DrawQueue::flush(Project *project)
     bx::HashMurmur2A hasher;
     for (PassCommandBufferList::const_iterator it = m_commandBuffers.begin(), end = m_commandBuffers.end(); it != end;
          ++it) {
-        drawPass(it, project, hasher);
+        const sg_pass pass = it->m_handle;
+        if (sg::query_pass_state(pass) == SG_RESOURCESTATE_VALID) {
+            drawPass(it, project, hasher);
+        }
+        else {
+            SG_INSERT_MARKERF("[WARN] The pass \"%s\" (%d) was skipped", project->findRenderPassName(pass), pass.id);
+        }
         nanoem_delete(it->m_items);
     }
     m_commandBuffers.clear();


### PR DESCRIPTION
## Summary

The PR adds skipping invalid pass to prevent assertion errors in `sokol_gfx`.

## Details

(none)

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
