### PR TITLE
[emapp] add sval_utf8 to effect::Annotation

### DIFF
--- a/emapp/resources/protobuf/effect.proto
+++ b/emapp/resources/protobuf/effect.proto
@@ -188,6 +188,7 @@ message Annotation {
     string sval = 5;
     Vector4i ival4 = 6;
     Vector4f fval4 = 7;
+    string sval_utf8 = 8;
   }
 };
 

--- a/emapp/src/protoc/effect.pb-c.c
+++ b/emapp/src/protoc/effect.pb-c.c
@@ -2248,7 +2248,7 @@ const ProtobufCMessageDescriptor fx9__effect__parameter__descriptor =
   (ProtobufCMessageInit) fx9__effect__parameter__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor fx9__effect__annotation__field_descriptors[7] =
+static const ProtobufCFieldDescriptor fx9__effect__annotation__field_descriptors[8] =
 {
   {
     "name",
@@ -2334,6 +2334,18 @@ static const ProtobufCFieldDescriptor fx9__effect__annotation__field_descriptors
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+  {
+    "sval_utf8",
+    8,
+    PROTOBUF_C_LABEL_OPTIONAL,
+    PROTOBUF_C_TYPE_STRING,
+    offsetof(Fx9__Effect__Annotation, value_case),
+    offsetof(Fx9__Effect__Annotation, sval_utf8),
+    NULL,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
 };
 static const unsigned fx9__effect__annotation__field_indices_by_name[] = {
   1,   /* field[1] = bval */
@@ -2343,11 +2355,12 @@ static const unsigned fx9__effect__annotation__field_indices_by_name[] = {
   5,   /* field[5] = ival4 */
   0,   /* field[0] = name */
   4,   /* field[4] = sval */
+  7,   /* field[7] = sval_utf8 */
 };
 static const ProtobufCIntRange fx9__effect__annotation__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 7 }
+  { 0, 8 }
 };
 const ProtobufCMessageDescriptor fx9__effect__annotation__descriptor =
 {
@@ -2357,7 +2370,7 @@ const ProtobufCMessageDescriptor fx9__effect__annotation__descriptor =
   "Fx9__Effect__Annotation",
   "fx9.effect",
   sizeof(Fx9__Effect__Annotation),
-  7,
+  8,
   fx9__effect__annotation__field_descriptors,
   fx9__effect__annotation__field_indices_by_name,
   1,  fx9__effect__annotation__number_ranges,

--- a/emapp/src/protoc/effect.pb-c.h
+++ b/emapp/src/protoc/effect.pb-c.h
@@ -345,7 +345,8 @@ typedef enum {
   FX9__EFFECT__ANNOTATION__VALUE_IVAL = 4,
   FX9__EFFECT__ANNOTATION__VALUE_SVAL = 5,
   FX9__EFFECT__ANNOTATION__VALUE_IVAL4 = 6,
-  FX9__EFFECT__ANNOTATION__VALUE_FVAL4 = 7
+  FX9__EFFECT__ANNOTATION__VALUE_FVAL4 = 7,
+  FX9__EFFECT__ANNOTATION__VALUE_SVAL_UTF8 = 8
     PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(FX9__EFFECT__ANNOTATION__VALUE__CASE)
 } Fx9__Effect__Annotation__ValueCase;
 
@@ -361,6 +362,7 @@ struct  Fx9__Effect__Annotation
     char *sval;
     Fx9__Effect__Vector4i *ival4;
     Fx9__Effect__Vector4f *fval4;
+    char *sval_utf8;
   };
 };
 #define FX9__EFFECT__ANNOTATION__INIT \


### PR DESCRIPTION
## Summary

This PR adds `sval_utf8` field in `effect::Annotation` (details in the commit message).

## Details

(none)

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
