### PR TITLE
[github] remove `paths-ignore` to run workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - 'docs/**'
 
 jobs:
   build-linux:


### PR DESCRIPTION
## Summary

This PR removes `paths-ignore` to run workflow and satisfy status check properly.

## Details

(none)

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
