### PR TITLE
[win32] add D3D11On12 layer support 

### DIFF
--- a/win32/CMakeLists.txt
+++ b/win32/CMakeLists.txt
@@ -1,5 +1,6 @@
 option(NANOEM_ENABLE_UPLOAD_PDB "Enable uploading debug symbols to sentry.io" OFF)
 option(NANOEM_ENABLE_RENDERDOC_WIN32 "Enable renderdoc integration" OFF)
+option(NANOEM_ENABLE_D3D11ON12 "Enable D3D11On12 layer" OFF)
 if(MSVC)
   set(CMAKE_EXE_LINKER_FLAGS "/LARGEADDRESSAWARE")
 endif()
@@ -39,6 +40,10 @@ if(NANOEM_ENABLE_RENDERDOC_WIN32)
   target_include_directories(${NANOEM_EXECUTABLE_NAME} PRIVATE ${RENDERDOC_INCLUDE_DIR})
   add_custom_command(TARGET ${NANOEM_EXECUTABLE_NAME} POST_BUILD
                      COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different "${RENDERDOC_LIBRARY_DIR}/renderdoc.dll" "$<TARGET_FILE_DIR:${NANOEM_EXECUTABLE_NAME}>")
+endif()
+if(NANOEM_ENABLE_D3D11ON12)
+  target_compile_definitions(${NANOEM_EXECUTABLE_NAME} PRIVATE NANOEM_ENABLE_D3D11ON12)
+  target_link_libraries(${NANOEM_EXECUTABLE_NAME} d3d12)
 endif()
 
 # integration

--- a/win32/include/MainWindow.h
+++ b/win32/include/MainWindow.h
@@ -9,10 +9,8 @@
 #define NANOEM_EMAPP_WIN32_MAINWINDOW_H_
 
 #include <Windows.h>
-#include <d3d11.h>
-#include <dxgi.h>
 #include <shellapi.h>
-#include <windowsx.h>
+#include <dxgi.h>
 
 #include "Win32ApplicationMenuBuilder.h"
 #include "emapp/BaseApplicationService.h"
@@ -21,6 +19,8 @@
 #include "bx/os.h"
 
 struct IProgressDialog;
+struct ID3D12CommandQueue;
+struct ID3D12Device;
 
 namespace bx {
 class CommandLine;
@@ -175,6 +175,8 @@ private:
     void *m_device = nullptr;
     DXGI_SWAP_CHAIN_DESC m_swapChainDesc;
     IDXGISwapChain *m_swapChain = nullptr;
+    ID3D12Device *m_device12 = nullptr;
+    ID3D12CommandQueue *m_commandQueue = nullptr;
     tinystl::pair<IProgressDialog *, int> m_progressDialog =
         tinystl::make_pair(static_cast<IProgressDialog *>(nullptr), 0);
     HACCEL m_accelerators = nullptr;

--- a/win32/include/WASAPIAudioPlayer.h
+++ b/win32/include/WASAPIAudioPlayer.h
@@ -12,7 +12,6 @@
 
 #include <atomic>
 
-#include <audioclient.h>
 #include <audiopolicy.h>
 #include <mmdeviceapi.h>
 

--- a/win32/include/Win32ThreadedApplicationService.h
+++ b/win32/include/Win32ThreadedApplicationService.h
@@ -10,11 +10,13 @@
 
 #include "emapp/ThreadedApplicationService.h"
 
-#include <d3d11.h>
-
 #include <atomic>
 
 #include "imgui/imgui.h"
+
+struct ID3D11DepthStencilView;
+struct ID3D11RenderTargetView;
+struct ID3D11Texture2D;
 
 namespace nanoem {
 

--- a/win32/src/D3D11SkinDeformerFactory.cc
+++ b/win32/src/D3D11SkinDeformerFactory.cc
@@ -6,6 +6,8 @@
 
 #include "D3D11SkinDeformerFactory.h"
 
+#include <d3d11.h>
+
 #include "COMInline.h"
 #include "Win32ThreadedApplicationService.h"
 
@@ -18,8 +20,6 @@
 #if defined(NANOEM_ENABLE_TBB)
 #include "tbb/tbb.h"
 #endif /* NANOEM_ENABLE_TBB */
-
-#include <d3d11.h>
 
 namespace nanoem {
 namespace win32 {

--- a/win32/src/D3D11VideoRecorder.cc
+++ b/win32/src/D3D11VideoRecorder.cc
@@ -7,14 +7,6 @@
 #include "D3D11VideoRecorder.h"
 #if WINVER >= _WIN32_WINNT_WIN7
 
-#include "COMInline.h"
-#include "emapp/Error.h"
-#include "emapp/IAudioPlayer.h"
-#include "emapp/Project.h"
-#include "emapp/StringUtils.h"
-#include "emapp/internal/BlitPass.h"
-#include "emapp/private/CommonInclude.h"
-
 #include <d3d11.h>
 #include <dxgi.h>
 #include <evr.h>
@@ -22,6 +14,14 @@
 #include <mfidl.h>
 #include <mfreadwrite.h>
 #include <stdio.h>
+
+#include "COMInline.h"
+#include "emapp/Error.h"
+#include "emapp/IAudioPlayer.h"
+#include "emapp/Project.h"
+#include "emapp/StringUtils.h"
+#include "emapp/internal/BlitPass.h"
+#include "emapp/private/CommonInclude.h"
 
 namespace nanoem {
 namespace win32 {

--- a/win32/src/Dialog.cc
+++ b/win32/src/Dialog.cc
@@ -6,13 +6,13 @@
 
 #include "Dialog.h"
 
-#include "emapp/FileUtils.h"
-#include "emapp/StringUtils.h"
-#include "emapp/private/CommonInclude.h"
-
 #define STRICT_TYPED_ITEMIDS
 #include <ShObjIdl.h>
 #include <Shlwapi.h>
+
+#include "emapp/FileUtils.h"
+#include "emapp/StringUtils.h"
+#include "emapp/private/CommonInclude.h"
 
 namespace nanoem {
 namespace win32 {

--- a/win32/src/WASAPIAudioPlayer.cc
+++ b/win32/src/WASAPIAudioPlayer.cc
@@ -6,16 +6,16 @@
 
 #include "WASAPIAudioPlayer.h"
 
+#include <Mferror.h>
+#include <mfapi.h>
+#include <mftransform.h>
+#include <wmcodecdsp.h>
+
 #include "COMInline.h"
 #include "emapp/Constants.h"
 #include "emapp/Error.h"
 #include "emapp/IEventPublisher.h"
 #include "emapp/private/CommonInclude.h"
-
-#include <Mferror.h>
-#include <mfapi.h>
-#include <mftransform.h>
-#include <wmcodecdsp.h>
 
 namespace nanoem {
 namespace win32 {

--- a/win32/src/Win32ThreadedApplicationService.cc
+++ b/win32/src/Win32ThreadedApplicationService.cc
@@ -6,6 +6,10 @@
 
 #include "Win32ThreadedApplicationService.h"
 
+#include <ShlObj.h>
+#include <d3d11.h>
+#include <dxgi.h>
+
 #include "COMInline.h"
 #include "D3D11BackgroundDrawer.h"
 #include "D3D11SkinDeformerFactory.h"
@@ -31,10 +35,6 @@
 #if defined(NANOEM_ENABLE_RENDERDOC)
 #include "renderdoc_app.h"
 #endif /* NANOEM_ENABLE_RENDERDOC */
-
-#include <ShlObj.h>
-#include <d3d11.h>
-#include <dxgi.h>
 
 namespace nanoem {
 namespace win32 {


### PR DESCRIPTION
## Summary

The PR adds [D3D11On12](https://github.com/microsoft/D3D11On12) layer support via `NANOEM_ENABLE_D3D11ON12`.

## Details

(none)

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
