### PR TITLE
[emapp] separate loading PPM as image::PPM class

### DIFF
--- a/emapp/include/emapp/Effect.h
+++ b/emapp/include/emapp/Effect.h
@@ -396,7 +396,6 @@ private:
     tinystl::pair<const Model *, const Accessory *> findOffscreenOwnerObject(
         const IDrawable *ownerDrawable, const Project *project) const NANOEM_DECL_NOEXCEPT;
     void decodeImageData(const ByteArray &bytes, const ImageResourceParameter &parameter, Error &error);
-    void decodePortableFloatMapData(const ByteArray &bytes, const ImageResourceParameter &parameter, Error &error);
     void setNormalizedColorImageContainer(
         const String &name, int numMipLevels, effect::RenderTargetColorImageContainer *container);
     void resetPassDescription();

--- a/emapp/include/emapp/ImageLoader.h
+++ b/emapp/include/emapp/ImageLoader.h
@@ -154,6 +154,25 @@ private:
     sg_pixel_format m_format;
 };
 
+class PFM {
+public:
+    PFM();
+    ~PFM() NANOEM_DECL_NOEXCEPT;
+
+    bool decode(const ByteArray &bytes, Error &error);
+    void setImageDescription(sg_image_desc &desc) const NANOEM_DECL_NOEXCEPT;
+
+    sg_pixel_format format() const NANOEM_DECL_NOEXCEPT;
+    nanoem_u32_t width() const NANOEM_DECL_NOEXCEPT;
+    nanoem_u32_t height() const NANOEM_DECL_NOEXCEPT;
+
+private:
+    ByteArray m_image;
+    sg_pixel_format m_format;
+    nanoem_u32_t m_width;
+    nanoem_u32_t m_height;
+};
+
 } /* namespace image */
 
 class Image NANOEM_DECL_SEALED : public IImageView, private NonCopyable {
@@ -200,6 +219,7 @@ public:
 
     static image::APNG *decodeAPNG(ISeekableReader *reader, Error &error);
     static image::DDS *decodeDDS(IReader *reader, Error &error);
+    static image::PFM *decodePFM(const ByteArray &bytes, Error &error);
     static void copyImageDescrption(const sg_image_desc &desc, Image *image);
     static bool validateImageSize(const String &name, const sg_image_desc &desc, Error &error);
     static bool isScreenBMP(const char *path) NANOEM_DECL_NOEXCEPT;


### PR DESCRIPTION
## Summary

The PR separates loading PPM file as `image::PPM` class.

## Details

(none)

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
