### PR TITLE
[emapp] rewrite ImageLoader::APNG to make fuzzer-proof

### DIFF
--- a/emapp/include/emapp/ImageLoader.h
+++ b/emapp/include/emapp/ImageLoader.h
@@ -35,6 +35,7 @@ public:
     nanoem_u32_t height() const NANOEM_DECL_NOEXCEPT;
 
 private:
+    struct State;
 #pragma pack(push)
 #pragma pack(1)
     struct Header {
@@ -79,6 +80,13 @@ private:
         kBlendOpSource = 0,
         kBlendOpOver,
     };
+
+    nanoem_u32_t decodeAnimationControl(ISeekableReader *reader, State &state, Error &error);
+    nanoem_u32_t decodeFrameControl(ISeekableReader *reader, State &state, Error &error);
+    nanoem_u32_t decodeFrameData(ISeekableReader *reader, nanoem_u32_t chunkLength, State &state, Error &error);
+    nanoem_u32_t decodeImageData(ISeekableReader *reader, nanoem_u32_t chunkLength, State &state, Error &error);
+    nanoem_u32_t decodeImageEnd(State &state, Error &error);
+    nanoem_u32_t decodeImageHeader(ISeekableReader *reader, State &state, Error &error);
 
     Header m_header;
     AnimationControl m_control;

--- a/emapp/test/misc/imageloader.cc
+++ b/emapp/test/misc/imageloader.cc
@@ -85,8 +85,7 @@ TEST_CASE("imageloader_apng", "[emapp][misc]")
     CHECK_FALSE(loadAPNG(NANOEM_TEST_FIXTURE_PATH "/apngs/043.png", error));
     CHECK_THAT(error.reasonConstString(), Catch::Equals("APNG: Empty image sequence"));
     CHECK_FALSE(loadAPNG(NANOEM_TEST_FIXTURE_PATH "/apngs/044.png", error));
-    CHECK_THAT(
-        error.reasonConstString(), Catch::Equals("APNG: CRC chunk checksum (fcTL: 0x1000000 != 0x0) not matched"));
+    CHECK_THAT(error.reasonConstString(), Catch::Equals("APNG: Empty image sequence"));
     CHECK_FALSE(loadAPNG(NANOEM_TEST_FIXTURE_PATH "/apngs/045.png", error));
     CHECK_THAT(error.reasonConstString(), Catch::Equals("APNG: Empty animation control"));
     CHECK(loadAPNG(NANOEM_TEST_FIXTURE_PATH "/apngs/046.png", error));


### PR DESCRIPTION
## Summary

This PR rewirtes ImageLoader::APNG implementation to make fuzzer proof.

## Details

(none)

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
