### PR TITLE
[rust] delete atty dependency from plugin_wasm due to log crate unused

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -53,17 +53,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,7 +700,6 @@ name = "plugin_wasm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "atty",
  "maplit",
  "pretty_assertions",
  "rand",

--- a/rust/plugin_wasm/Cargo.toml
+++ b/rust/plugin_wasm/Cargo.toml
@@ -7,7 +7,6 @@ license = "MPL-2.0"
 
 [dependencies]
 anyhow = "1"
-atty = "0.2"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 wasmer = "2"

--- a/rust/plugin_wasm/src/lib.rs
+++ b/rust/plugin_wasm/src/lib.rs
@@ -107,9 +107,7 @@ fn inner_set_data_internal(
 }
 
 pub(crate) fn initialize_env_logger() {
-    if atty::is(atty::Stream::Stderr) {
-        tracing_subscriber::fmt::try_init().unwrap_or_default();
-    }
+    tracing_subscriber::fmt::try_init().unwrap_or_default();
 }
 
 pub(crate) fn inner_memory(instance: &Instance) -> &Memory {


### PR DESCRIPTION
## Summary

The PR deletes `atty` crate from dependency due to log crate is no longer be used

## Details

(none)

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
