### PR TITLE
[sapp] remove window size specification at initialize

### DIFF
--- a/sapp/main.cc
+++ b/sapp/main.cc
@@ -183,9 +183,6 @@ sokol_main(int argc, char *argv[])
         delete state;
         Allocator::destroy();
     };
-    const Vector2UI16 size(BaseApplicationService::minimumRequiredWindowSize());
-    desc.width = size.x;
-    desc.height = size.y;
     desc.window_title = "nanoem";
     desc.html5_canvas_resize = true;
     desc.html5_premultiplied_alpha = true;


### PR DESCRIPTION
## Summary

This PR removes window size specification at initialization for Linux with HiDPI environment.

## Details

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
