### PR TITLE
[win32] fixed a bug initialization failure doesn't show properly 

### DIFF
--- a/sapp/src/ApplicationService.cc
+++ b/sapp/src/ApplicationService.cc
@@ -226,9 +226,11 @@ ApplicationService::createSkinDeformerFactory()
         case SG_BACKEND_GLCORE33:
         case SG_BACKEND_GLES3: {
 #if defined(_WIN32)
+#if defined(NANOEM_WIN32_HAS_OPENGL)
             factory = nanoem_new(internal::OpenGLComputeShaderSkinDeformerFactory(
                 reinterpret_cast<internal ::OpenGLComputeShaderSkinDeformerFactory::PFN_GetProcAddress>(
                     wglGetProcAddress)));
+#endif /* NANOEM_WIN32_HAS_OPENGL */
 #else
             if (void *handle = bx::dlopen("libGL.so")) {
                 using PFN_glXGetProcAddress = internal::OpenGLComputeShaderSkinDeformerFactory::PFN_GetProcAddress;

--- a/win32/src/MainWindow.cc
+++ b/win32/src/MainWindow.cc
@@ -420,16 +420,17 @@ MainWindow::handleWindowProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
         if (auto self = static_cast<MainWindow *>(lpcs->lpCreateParams)) {
             Error error;
             if (!self->handleWindowCreate(hwnd, error)) {
-                char buffer[256];
-                StringUtils::format(buffer, sizeof(buffer),
-                    "Failed to initialize nanoem due to failure of setup DirectX/OpenGL: %s",
-                    error.reasonConstString());
-                MessageBoxA(hwnd, buffer, "nanoem", MB_ICONERROR);
-                DestroyAcceleratorTable(self->m_accelerators);
-                DestroyMenu(self->m_menuHandle);
                 self->m_running = false;
                 self->m_client->sendTerminateMessage();
                 result = -1;
+                wchar_t buffer[256];
+                MutableWideString ws;
+                StringUtils::getWideCharString(error.reasonConstString(), ws);
+                _snwprintf_s(buffer, BX_COUNTOF(buffer),
+                    L"Failed to initialize nanoem due to failure of setup DirectX/OpenGL: %s", ws.data());
+                MessageBoxW(hwnd, buffer, L"nanoem", MB_ICONERROR);
+                DestroyAcceleratorTable(self->m_accelerators);
+                DestroyMenu(self->m_menuHandle);
             }
         }
         break;

--- a/win32/src/Win32ThreadedApplicationService.cc
+++ b/win32/src/Win32ThreadedApplicationService.cc
@@ -596,6 +596,7 @@ Win32ThreadedApplicationService::createSkinDeformerFactory()
                 factory = nanoem_new(D3D11SkinDeformerFactory(device, context));
             }
         }
+#if defined(NANOEM_WIN32_HAS_OPENGL)
         else if (backend == SG_BACKEND_GLCORE33 || backend == SG_BACKEND_GLES3) {
             if (wglGetProcAddress("glDispatchCompute")) {
                 factory = nanoem_new(internal::OpenGLComputeShaderSkinDeformerFactory(
@@ -608,6 +609,7 @@ Win32ThreadedApplicationService::createSkinDeformerFactory()
                         wglGetProcAddress)));
             }
         }
+#endif /* NANOEM_WIN32_HAS_OPENGL */
     }
     return factory;
 }


### PR DESCRIPTION
## Summary

This PR contains following changes focused on Windows.

* Fixes a bug initialization failure message with garbled characters will be shown
* Link issue caused by `wglGetProcAddress` on WOA64

## Details

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
