### PR TITLE
[rust] bumps wasmer crate to `3.0.0-rc.1`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -35,6 +35,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
+name = "async-trait"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +455,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
@@ -456,6 +476,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "ident_case"
@@ -800,7 +826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.0",
  "itertools",
  "lazy_static",
  "log",
@@ -854,6 +880,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -1073,6 +1110,20 @@ name = "serde"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "serde_derive"
@@ -1304,6 +1355,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,10 +1428,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "valuable"
@@ -1452,15 +1548,17 @@ checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasmer"
-version = "3.0.0-beta.2"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fc47a9d4ebb42b3a9a3d802e809bbdb5afaf3028373a82b989e51f4e400903"
+checksum = "ee6eea8f768e7b4313e1db8f8f4d20cccf0999102d53a2c27e1d88ecdf0b638d"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
  "indexmap",
  "js-sys",
  "more-asserts",
+ "serde",
+ "serde-wasm-bindgen",
  "target-lexicon",
  "thiserror",
  "wasm-bindgen",
@@ -1474,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "3.0.0-beta.2"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54d7b5068f9ed673f0fc8513b4702067a0f5712d3ea226eb71fc4a9c6c4fe9c7"
+checksum = "e6aac0e272385c4e29cbd217f874df59362053a5bda95c340d0c90c2cf9e56ca"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -1498,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "3.0.0-beta.2"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0fac321e5d3dc4f157f28bf6001f06d2e821422ce60449da97d39af171b4169"
+checksum = "4930b0384f8754129eabcfbd2ac33eaea976aef7a573a2c73728df7a31bab54e"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1517,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "3.0.0-beta.2"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b38c7a442cffa5efb799631013bb30aeb1d553c50effa51905ea8b36ecc6c8"
+checksum = "75f1bc5a30f2b49dc52fe5ac9487b22b69985032f9a9b7b6d7dc27c56fca6430"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1529,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "3.0.0-beta.2"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d47fb87929c956693d68393d4778670ed1ce9733804b74bbd5fa6fa6d725250"
+checksum = "0065ac636258dd9277d69210ad881df5f7973491e693a7e877b0e4389afe5a2c"
 dependencies = [
  "enum-iterator",
  "enumset",
@@ -1544,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vbus"
-version = "3.0.0-beta.2"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd8032075e49d9935ff2ea69360c85f5b942fe0bc5f777a0278f2b039145e"
+checksum = "b3873de544e32d21953ce526c28d478e23c75fa7e574eb0104800302529ae0e4"
 dependencies = [
  "thiserror",
  "wasmer-vfs",
@@ -1554,9 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vfs"
-version = "3.0.0-beta.2"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dee30860fda7b4e37601624ccb3273fba67d7ac850d6a7338ce922ca2aa5737"
+checksum = "02ae1e172fd3d57e25b339eb0db78d7401366c9091730cb5faf4fa603b5153cc"
 dependencies = [
  "slab",
  "thiserror",
@@ -1565,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "3.0.0-beta.2"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a72cac9f0ce7a9f3d0fe01604202270cdfe8d3dae9d84742b85c5d935cad74d"
+checksum = "366dc013296afba61854d4729e360367dd1fb6651266ef1f904059dbdc1d838a"
 dependencies = [
  "backtrace",
  "cc",
@@ -1589,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vnet"
-version = "3.0.0-beta.2"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b808bda0282639f7d590b75e1eb87339d34adbb5504fe6784e993549f275f2c"
+checksum = "e2a127fd94dd7b3fbba68c2446bab779f7b7dde3de8fa8dfd6242c5cfb2624f1"
 dependencies = [
  "bytes",
  "thiserror",
@@ -1600,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi"
-version = "3.0.0-beta.2"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f757f3c46db35742d56bea0a7f695c33abeb468bfa71a68a09d2c04239fb3b"
+checksum = "58f3bd1aef78b748e2be1fb8ac04638910d85b59d38ca2a43aaeb3e336d9be56"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
@@ -1623,14 +1721,86 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi-types"
-version = "3.0.0-beta.2"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ada7a7fc8ac363e750518f3a81257cbc9d7188895a05fbe5e557b9d7a6366c"
+checksum = "0777021b8eba997fe2e0bc315de2c0f897d9f22d91dd8822a3eca26ba7652f9b"
 dependencies = [
  "byteorder",
  "time",
+ "wasmer",
  "wasmer-derive",
  "wasmer-types",
+ "wasmer-wit-bindgen-gen-core",
+ "wasmer-wit-bindgen-gen-rust-wasm",
+ "wasmer-wit-bindgen-rust",
+ "wasmer-wit-parser",
+]
+
+[[package]]
+name = "wasmer-wit-bindgen-gen-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff8aa5be5ae5d61f5e151dc2c0e603093fe28395d2083b65ef7a3547844054fe"
+dependencies = [
+ "anyhow",
+ "wasmer-wit-parser",
+]
+
+[[package]]
+name = "wasmer-wit-bindgen-gen-rust"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "438bce7c4589842bf100cc9b312443a9b5fc6440e58ab0b8c114e460219c3c3b"
+dependencies = [
+ "heck 0.3.3",
+ "wasmer-wit-bindgen-gen-core",
+]
+
+[[package]]
+name = "wasmer-wit-bindgen-gen-rust-wasm"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "505f5168cfee591840e13e158a5c5e2f95d6df1df710839021564f36bee7bafc"
+dependencies = [
+ "heck 0.3.3",
+ "wasmer-wit-bindgen-gen-core",
+ "wasmer-wit-bindgen-gen-rust",
+]
+
+[[package]]
+name = "wasmer-wit-bindgen-rust"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "968747f1271f74aab9b70d9c5d4921db9bd13b4ec3ba5506506e6e7dc58c918c"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "wasmer-wit-bindgen-rust-impl",
+]
+
+[[package]]
+name = "wasmer-wit-bindgen-rust-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd26fe00d08bd2119870b017d13413dfbd51e7750b6634d649fc7a7bbc057b85"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "wasmer-wit-bindgen-gen-core",
+ "wasmer-wit-bindgen-gen-rust-wasm",
+]
+
+[[package]]
+name = "wasmer-wit-parser"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46c9a15086be8a2eb3790613902b9d3a9a687833b17cd021de263a20378585a"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "pulldown-cmark",
+ "unicode-normalization",
+ "unicode-xid",
 ]
 
 [[package]]

--- a/rust/plugin_wasm/Cargo.toml
+++ b/rust/plugin_wasm/Cargo.toml
@@ -9,8 +9,14 @@ license = "MPL-2.0"
 anyhow = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = "0.3"
-wasmer = { version = "3.0.0-beta", default-features = false, features = ["sys", "cranelift"] }
-wasmer-wasi = { version = "3.0.0-beta", default-features = false, features = ["sys", "mem-fs"] }
+wasmer = { version = "3.0.0-rc.1", default-features = false, features = [
+    "sys",
+    "cranelift",
+] }
+wasmer-wasi = { version = "3.0.0-rc.1", default-features = false, features = [
+    "sys",
+    "mem-fs",
+] }
 walkdir = "2"
 
 [dev-dependencies]

--- a/rust/plugin_wasm/src/motion/test/full.rs
+++ b/rust/plugin_wasm/src/motion/test/full.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, Result};
 use maplit::hashmap;
 use pretty_assertions::assert_eq;
 use serde_json::json;
+use wasmer_wasi::WasiBidirectionalSharedPipePair;
 
 use crate::motion::{
     plugin::MotionIOPluginController,
@@ -19,22 +20,24 @@ use crate::motion::{
 
 use super::build_type_and_flags;
 
-fn create_controller() -> Result<MotionIOPluginController> {
+fn create_controller(
+    pipe: &mut WasiBidirectionalSharedPipePair,
+) -> Result<MotionIOPluginController> {
     let package = "plugin_wasm_test_motion_full";
     let (ty, flag) = build_type_and_flags();
-    inner_create_controller(&format!("target/wasm32-wasi/{}/{}.wasm", ty, package)).with_context(
-        || {
+    inner_create_controller(pipe, &format!("target/wasm32-wasi/{}/{}.wasm", ty, package))
+        .with_context(|| {
             format!(
                 "try build with \"cargo build --package {} --target wasm32-wasi{}\"",
                 package, flag
             )
-        },
-    )
+        })
 }
 
 #[test]
 fn create() -> Result<()> {
-    let result = create_controller();
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let result = create_controller(&mut pipe);
     assert!(result.is_ok());
     let mut controller = result?;
     assert!(controller.initialize().is_ok());
@@ -74,7 +77,7 @@ fn create() -> Result<()> {
                 })
             },
         ],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     assert_eq!(2, controller.count_all_functions());
     assert_eq!(
@@ -98,18 +101,19 @@ fn create() -> Result<()> {
                 ..Default::default()
             },
         ],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     Ok(())
 }
 
 #[test]
 fn set_language() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     controller.initialize()?;
     controller.create()?;
     controller.set_function(0)?;
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     assert!(controller.set_language(0).is_ok());
     assert_eq!(
         vec![PluginOutput {
@@ -118,7 +122,7 @@ fn set_language() -> Result<()> {
                 "value".to_owned() => json!(0),
             })
         },],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     controller.destroy();
     controller.terminate();
@@ -127,12 +131,13 @@ fn set_language() -> Result<()> {
 
 #[test]
 fn execute() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     let data = create_random_data(4096);
     controller.initialize()?;
     controller.create()?;
     controller.set_function(0)?;
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     assert!(controller.set_input_model_data(&data).is_ok());
     assert!(controller.set_input_motion_data(&data).is_ok());
     assert!(controller.execute().is_ok());
@@ -178,7 +183,7 @@ fn execute() -> Result<()> {
                 })
             },
         ],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     controller.destroy();
     controller.terminate();
@@ -187,12 +192,13 @@ fn execute() -> Result<()> {
 
 #[test]
 fn set_all_selected_accessory_keyframes() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     let data = &[1, 4, 9, 16, 25, u32::MAX];
     controller.initialize()?;
     controller.create()?;
     controller.set_function(0)?;
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     assert!(controller
         .set_all_selected_accessory_keyframes(data)
         .is_ok());
@@ -205,7 +211,7 @@ fn set_all_selected_accessory_keyframes() -> Result<()> {
                 "status".to_owned() => json!(0),
             })
         },],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     controller.destroy();
     controller.terminate();
@@ -214,12 +220,13 @@ fn set_all_selected_accessory_keyframes() -> Result<()> {
 
 #[test]
 fn set_all_selected_camera_keyframes() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     let data = &[1, 4, 9, 16, 25, u32::MAX];
     controller.initialize()?;
     controller.create()?;
     controller.set_function(0)?;
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     assert!(controller.set_all_selected_camera_keyframes(data).is_ok());
     assert_eq!(
         vec![PluginOutput {
@@ -230,7 +237,7 @@ fn set_all_selected_camera_keyframes() -> Result<()> {
                 "status".to_owned() => json!(0),
             })
         },],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     controller.destroy();
     controller.terminate();
@@ -239,12 +246,13 @@ fn set_all_selected_camera_keyframes() -> Result<()> {
 
 #[test]
 fn set_all_selected_light_keyframes() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     let data = &[1, 4, 9, 16, 25, u32::MAX];
     controller.initialize()?;
     controller.create()?;
     controller.set_function(0)?;
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     assert!(controller.set_all_selected_light_keyframes(data).is_ok());
     assert_eq!(
         vec![PluginOutput {
@@ -255,7 +263,7 @@ fn set_all_selected_light_keyframes() -> Result<()> {
                 "status".to_owned() => json!(0),
             })
         },],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     controller.destroy();
     controller.terminate();
@@ -264,12 +272,13 @@ fn set_all_selected_light_keyframes() -> Result<()> {
 
 #[test]
 fn set_all_selected_model_keyframes() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     let data = &[1, 4, 9, 16, 25, u32::MAX];
     controller.initialize()?;
     controller.create()?;
     controller.set_function(0)?;
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     assert!(controller.set_all_selected_model_keyframes(data).is_ok());
     assert_eq!(
         vec![PluginOutput {
@@ -280,7 +289,7 @@ fn set_all_selected_model_keyframes() -> Result<()> {
                 "status".to_owned() => json!(0),
             })
         },],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     controller.destroy();
     controller.terminate();
@@ -289,12 +298,13 @@ fn set_all_selected_model_keyframes() -> Result<()> {
 
 #[test]
 fn set_all_selected_self_shadow_keyframes() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     let data = &[1, 4, 9, 16, 25, u32::MAX];
     controller.initialize()?;
     controller.create()?;
     controller.set_function(0)?;
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     assert!(controller
         .set_all_selected_self_shadow_keyframes(data)
         .is_ok());
@@ -307,7 +317,7 @@ fn set_all_selected_self_shadow_keyframes() -> Result<()> {
                 "status".to_owned() => json!(0),
             })
         },],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     controller.destroy();
     controller.terminate();
@@ -316,12 +326,13 @@ fn set_all_selected_self_shadow_keyframes() -> Result<()> {
 
 #[test]
 fn set_all_named_selected_bone_keyframes() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     let data = &[1, 4, 9, 16, 25, u32::MAX];
     controller.initialize()?;
     controller.create()?;
     controller.set_function(0)?;
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     assert!(controller
         .set_all_named_selected_bone_keyframes("bone", data)
         .is_ok());
@@ -335,7 +346,7 @@ fn set_all_named_selected_bone_keyframes() -> Result<()> {
                 "status".to_owned() => json!(0),
             })
         },],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     controller.destroy();
     controller.terminate();
@@ -344,12 +355,13 @@ fn set_all_named_selected_bone_keyframes() -> Result<()> {
 
 #[test]
 fn set_all_named_selected_morph_keyframes() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     let data = &[1, 4, 9, 16, 25, u32::MAX];
     controller.initialize()?;
     controller.create()?;
     controller.set_function(0)?;
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     assert!(controller
         .set_all_named_selected_morph_keyframes("morph", data)
         .is_ok());
@@ -363,7 +375,7 @@ fn set_all_named_selected_morph_keyframes() -> Result<()> {
                 "status".to_owned() => json!(0),
             })
         },],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     controller.destroy();
     controller.terminate();
@@ -372,12 +384,13 @@ fn set_all_named_selected_morph_keyframes() -> Result<()> {
 
 #[test]
 fn set_audio_description() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     let data = create_random_data(4096);
     controller.initialize()?;
     controller.create()?;
     controller.set_function(0)?;
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     assert!(controller.set_audio_description(&data).is_ok());
     assert_eq!(
         vec![PluginOutput {
@@ -388,7 +401,7 @@ fn set_audio_description() -> Result<()> {
                 "status".to_owned() => json!(0),
             })
         },],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     controller.destroy();
     controller.terminate();
@@ -397,12 +410,13 @@ fn set_audio_description() -> Result<()> {
 
 #[test]
 fn set_audio_data() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     let data = create_random_data(4096);
     controller.initialize()?;
     controller.create()?;
     controller.set_function(0)?;
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     assert!(controller.set_audio_data(&data).is_ok());
     assert_eq!(
         vec![PluginOutput {
@@ -413,7 +427,7 @@ fn set_audio_data() -> Result<()> {
                 "status".to_owned() => json!(0),
             })
         },],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     controller.destroy();
     controller.terminate();
@@ -422,12 +436,13 @@ fn set_audio_data() -> Result<()> {
 
 #[test]
 fn set_camera_description() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     let data = create_random_data(4096);
     controller.initialize()?;
     controller.create()?;
     controller.set_function(0)?;
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     assert!(controller.set_camera_description(&data).is_ok());
     assert_eq!(
         vec![PluginOutput {
@@ -438,7 +453,7 @@ fn set_camera_description() -> Result<()> {
                 "status".to_owned() => json!(0),
             })
         },],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     controller.destroy();
     controller.terminate();
@@ -447,12 +462,13 @@ fn set_camera_description() -> Result<()> {
 
 #[test]
 fn set_light_description() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     let data = create_random_data(4096);
     controller.initialize()?;
     controller.create()?;
     controller.set_function(0)?;
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     assert!(controller.set_light_description(&data).is_ok());
     assert_eq!(
         vec![PluginOutput {
@@ -463,7 +479,7 @@ fn set_light_description() -> Result<()> {
                 "status".to_owned() => json!(0),
             })
         },],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     controller.destroy();
     controller.terminate();
@@ -472,12 +488,13 @@ fn set_light_description() -> Result<()> {
 
 #[test]
 fn ui_window() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     let data = create_random_data(4096);
     controller.initialize()?;
     controller.create()?;
     controller.set_function(0)?;
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     assert!(controller.load_ui_window_layout().is_ok());
     let output = controller.get_ui_window_layout();
     assert!(output.is_ok());
@@ -518,7 +535,7 @@ fn ui_window() -> Result<()> {
                 })
             },
         ],
-        read_plugin_output(&mut controller)?
+        read_plugin_output(&mut pipe)?
     );
     controller.destroy();
     controller.terminate();
@@ -527,16 +544,17 @@ fn ui_window() -> Result<()> {
 
 #[test]
 fn get_failure_reason() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     controller.initialize()?;
     controller.create()?;
     controller.set_function(1)?;
     controller.execute().unwrap_or_default();
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     let result = controller.failure_reason();
     assert!(result.is_some());
     assert_eq!("Failure Reason", result.unwrap());
-    assert!(read_plugin_output(&mut controller)?.is_empty());
+    assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
     Ok(())
@@ -544,16 +562,17 @@ fn get_failure_reason() -> Result<()> {
 
 #[test]
 fn get_recovery_suggestion() -> Result<()> {
-    let mut controller = create_controller()?;
+    let mut pipe = WasiBidirectionalSharedPipePair::new().with_blocking(false);
+    let mut controller = create_controller(&mut pipe)?;
     controller.initialize()?;
     controller.create()?;
     controller.set_function(1)?;
     controller.execute().unwrap_or_default();
-    flush_plugin_output(&mut controller)?;
+    flush_plugin_output(&mut pipe)?;
     let result = controller.recovery_suggestion();
     assert!(result.is_some());
     assert_eq!("Recovery Suggestion", result.unwrap());
-    assert!(read_plugin_output(&mut controller)?.is_empty());
+    assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
     Ok(())

--- a/rust/plugin_wasm/src/motion/test/mod.rs
+++ b/rust/plugin_wasm/src/motion/test/mod.rs
@@ -7,6 +7,7 @@
 use std::{
     collections::{HashMap, HashSet},
     env::current_dir,
+    io::Read,
     sync::Arc,
 };
 
@@ -16,7 +17,9 @@ use rand::{thread_rng, Rng};
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 use wasmer::Store;
-use wasmer_wasi::{types::__WASI_STDOUT_FILENO, Pipe, WasiFunctionEnv, WasiState};
+use wasmer_wasi::{
+    types::__WASI_STDOUT_FILENO, Pipe, WasiBidirectionalSharedPipePair, WasiFunctionEnv, WasiState,
+};
 
 use super::plugin::{MotionIOPlugin, MotionIOPluginController};
 
@@ -34,9 +37,13 @@ fn build_type_and_flags() -> (&'static str, &'static str) {
     }
 }
 
-fn create_wasi_env(store: &mut Store) -> Result<WasiFunctionEnv> {
-    let stdout = Box::new(Pipe::new());
-    Ok(WasiState::new("nanoem").stdout(stdout).finalize(store)?)
+fn create_wasi_env(
+    pipe: &mut WasiBidirectionalSharedPipePair,
+    store: &mut Store,
+) -> Result<WasiFunctionEnv> {
+    Ok(WasiState::new("nanoem")
+        .stdout(Box::new(pipe.clone()))
+        .finalize(store)?)
 }
 
 fn create_random_data(size: usize) -> Vec<u8> {
@@ -49,23 +56,15 @@ fn create_random_data(size: usize) -> Vec<u8> {
     data
 }
 
-fn flush_plugin_output(controller: &mut MotionIOPluginController) -> Result<()> {
-    let plugin = controller.all_plugins_mut().first_mut().unwrap();
-    let env = plugin.wasi_env();
-    let mut stdout = env.state().stdout()?;
-    let stdout = stdout.as_mut().unwrap();
+fn flush_plugin_output(pipe: &mut WasiBidirectionalSharedPipePair) -> Result<()> {
     let mut v = vec![];
-    stdout.read_to_end(&mut v)?;
+    pipe.read_to_end(&mut v)?;
     Ok(())
 }
 
-fn read_plugin_output(controller: &mut MotionIOPluginController) -> Result<Vec<PluginOutput>> {
-    let plugin = controller.all_plugins_mut().first_mut().unwrap();
-    let env = plugin.wasi_env();
-    let mut stdout = env.state().stdout()?;
-    let stdout = stdout.as_mut().unwrap();
+fn read_plugin_output(pipe: &mut WasiBidirectionalSharedPipePair) -> Result<Vec<PluginOutput>> {
     let mut s = String::new();
-    stdout.read_to_string(&mut s)?;
+    pipe.read_to_string(&mut s)?;
     let mut data: Vec<_> = s.split('\n').collect();
     data.pop();
     Ok(data
@@ -74,10 +73,13 @@ fn read_plugin_output(controller: &mut MotionIOPluginController) -> Result<Vec<P
         .collect())
 }
 
-fn inner_create_controller(path: &str) -> Result<MotionIOPluginController> {
+fn inner_create_controller(
+    pipe: &mut WasiBidirectionalSharedPipePair,
+    path: &str,
+) -> Result<MotionIOPluginController> {
     let path = current_dir()?.parent().unwrap().join(path);
     let mut store = Store::default();
-    let env = create_wasi_env(&mut store)?;
+    let env = create_wasi_env(pipe, &mut store)?;
     let bytes = std::fs::read(path)?;
     let plugin = MotionIOPlugin::new(&bytes, env, store)?;
     Ok(MotionIOPluginController::new(vec![plugin]))


### PR DESCRIPTION
## Summary

The PR bumps wasmer crate to `3.0.0-rc.1` and fix a timeout issue at running tests due to blocking stdout.

## Details

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
