### PR TITLE
[dependencies] bumps spdlog to v1.11

### DIFF
--- a/emapp/include/emapp/private/CommonInclude.h
+++ b/emapp/include/emapp/private/CommonInclude.h
@@ -25,6 +25,9 @@
 #if NANOEM_ENABLE_LOGGING
 #define SPDLOG_DISABLE_DEFAULT_LOGGER
 #define SPDLOG_NO_EXCEPTIONS
+#ifdef NDEBUG
+#define SPDLOG_NO_SOURCE_LOC
+#endif /* NDEBUG */
 #include "spdlog/spdlog.h"
 #define EMLOG_TRACE(format, ...)                                                                                       \
     do {                                                                                                               \

--- a/emapp/resources/credits.md
+++ b/emapp/resources/credits.md
@@ -49,7 +49,7 @@ This software uses below libraries.
   - [protobuf-c](https://github.com/protobuf-c/protobuf-c/)
     - [BSDL](https://github.com/protobuf-c/protobuf-c/blob/f224ab2eeb648a818eb20687d7150a285442c907/LICENSE)
   - [spdlog](https://github.com/gabime/spdlog)
-    - [MIT](https://github.com/gabime/spdlog/blob/76fb40d95455f249bd70824ecfcae7a8f0930fa3/LICENSE)
+    - [MIT](https://github.com/gabime/spdlog/blob/ad0e89cbfb4d0c1ce4d097e134eb7be67baebb36/LICENSE)
   - [sentry-native](https://github.com/getsentry/sentry-native)
     - [MIT](https://github.com/getsentry/sentry-native/blob/ff5bfcf0eb2c47d03eb57a51bdf2e6ad4b8ece10/LICENSE)
   - [sokol](https://github.com/hkrn/sokol)

--- a/macos/Resources/English.lproj/Credits.rtf
+++ b/macos/Resources/English.lproj/Credits.rtf
@@ -192,7 +192,7 @@ BSDL
 spdlog
 }}}
 \par}
-{\pard \ql \f0 \sa0 \li720 \fi-360 \endash \tx360\tab {\field{\*\fldinst{HYPERLINK "https://github.com/gabime/spdlog/blob/76fb40d95455f249bd70824ecfcae7a8f0930fa3/LICENSE"}}{\fldrslt{\ul
+{\pard \ql \f0 \sa0 \li720 \fi-360 \endash \tx360\tab {\field{\*\fldinst{HYPERLINK "https://github.com/gabime/spdlog/blob/ad0e89cbfb4d0c1ce4d097e134eb7be67baebb36/LICENSE"}}{\fldrslt{\ul
 MIT
 }}}
 \sa180\par}


### PR DESCRIPTION
## Summary

This PR bumps `spdlog` to v1.11

## Details

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
