### PR TITLE
[emapp] fixed a bug offscreen passive effect cannot be enabled properly

### DIFF
--- a/emapp/src/Accessory.cc
+++ b/emapp/src/Accessory.cc
@@ -711,7 +711,7 @@ Accessory::setOffscreenPassiveRenderTargetEffectEnabled(const String &ownerName,
             it->second.m_enabled = value;
         }
         else {
-            OffscreenPassiveRenderTargetEffect effect = { nullptr, true };
+            OffscreenPassiveRenderTargetEffect effect = { nullptr, value };
             m_offscreenPassiveRenderTargetEffects.insert(tinystl::make_pair(ownerName, effect));
         }
     }

--- a/emapp/src/Model.cc
+++ b/emapp/src/Model.cc
@@ -2434,7 +2434,7 @@ Model::setOffscreenPassiveRenderTargetEffectEnabled(const String &ownerName, boo
             it->second.m_enabled = value;
         }
         else {
-            OffscreenPassiveRenderTargetEffect effect = { nullptr, true };
+            OffscreenPassiveRenderTargetEffect effect = { nullptr, value };
             m_offscreenPassiveRenderTargetEffects.insert(tinystl::make_pair(ownerName, effect));
         }
     }

--- a/emapp/src/Project.cc
+++ b/emapp/src/Project.cc
@@ -7267,7 +7267,8 @@ Project::applyDrawableToOffscreenRenderTargetEffect(IDrawable *drawable, Effect 
                 const OffscreenRenderTargetCondition &condition = *it3;
                 matched = matchDrawableEffect(drawable, ownerEffect, condition.m_pattern);
                 if (matched) {
-                    if (!condition.m_hidden) {
+                    const bool enabled = !condition.m_hidden;
+                    if (enabled) {
                         if (!condition.m_none) {
                             setOffscreenPassiveRenderTargetEffect(ownerName, drawable, condition.m_passiveEffect);
                         }
@@ -7275,6 +7276,7 @@ Project::applyDrawableToOffscreenRenderTargetEffect(IDrawable *drawable, Effect 
                             drawable->setOffscreenDefaultRenderTargetEffect(ownerName);
                         }
                     }
+                    drawable->setOffscreenPassiveRenderTargetEffectEnabled(ownerName, enabled);
                     break;
                 }
             }


### PR DESCRIPTION
## Summary

The PR fixes a bug offscreen passive effect cannot be enabled properly, and should not be hidden on dialog.

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
