### PR TITLE
[dependencies] updates sokol's fork

### DIFF
--- a/emapp/resources/credits.md
+++ b/emapp/resources/credits.md
@@ -53,7 +53,7 @@ This software uses below libraries.
   - [sentry-native](https://github.com/getsentry/sentry-native)
     - [MIT](https://github.com/getsentry/sentry-native/blob/ff5bfcf0eb2c47d03eb57a51bdf2e6ad4b8ece10/LICENSE)
   - [sokol](https://github.com/hkrn/sokol)
-    - [zlib](https://github.com/hkrn/sokol/blob/f2ca4a90d6510faded080e610de0a934d40ac485/LICENSE)
+    - [zlib](https://github.com/hkrn/sokol/blob/604a144407c1174399c4f16d2dd1dd673b8cfca4/LICENSE)
   - [SPIRV-Cross](https://github.com/KhronosGroup/SPIRV-Cross/)
     - [Apache License 2.0](https://github.com/KhronosGroup/SPIRV-Cross/blob/9acb9ec31f5a8ef80ea6b994bb77be787b08d3d1/LICENSE)
   - [SPIRV-Tools](https://github.com/KhronosGroup/SPIRV-Tools/)

--- a/macos/Resources/English.lproj/Credits.rtf
+++ b/macos/Resources/English.lproj/Credits.rtf
@@ -208,7 +208,7 @@ MIT
 sokol
 }}}
 \par}
-{\pard \ql \f0 \sa0 \li720 \fi-360 \endash \tx360\tab {\field{\*\fldinst{HYPERLINK "https://github.com/hkrn/sokol/blob/f2ca4a90d6510faded080e610de0a934d40ac485/LICENSE"}}{\fldrslt{\ul
+{\pard \ql \f0 \sa0 \li720 \fi-360 \endash \tx360\tab {\field{\*\fldinst{HYPERLINK "https://github.com/hkrn/sokol/blob/604a144407c1174399c4f16d2dd1dd673b8cfca4/LICENSE"}}{\fldrslt{\ul
 zlib
 }}}
 \sa180\par}


### PR DESCRIPTION
## Summary

The PR updates forked sokol to https://github.com/hkrn/sokol/tree/20230115-blendop-minmax

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
