### PR TITLE
[rust] apply all fixes of rust clippy warnings

### DIFF
--- a/rust/plugin_wasm/src/model/test/full.rs
+++ b/rust/plugin_wasm/src/model/test/full.rs
@@ -20,11 +20,10 @@ use super::{build_type_and_flags, inner_create_controller};
 fn create_controller(pipe: &mut Pipe) -> Result<ModelIOPluginController> {
     let package = "plugin_wasm_test_model_full";
     let (ty, flag) = build_type_and_flags();
-    inner_create_controller(pipe, &format!("target/wasm32-wasi/{}/{}.wasm", ty, package))
+    inner_create_controller(pipe, &format!("target/wasm32-wasi/{ty}/{package}.wasm"))
         .with_context(|| {
             format!(
-                "try build with \"cargo build --package {} --target wasm32-wasi{}\"",
-                package, flag
+                "try build with \"cargo build --package {package} --target wasm32-wasi{flag}\""
             )
         })
 }

--- a/rust/plugin_wasm/src/model/test/minimum.rs
+++ b/rust/plugin_wasm/src/model/test/minimum.rs
@@ -20,11 +20,10 @@ use super::{build_type_and_flags, inner_create_controller};
 fn create_controller(pipe: &mut Pipe) -> Result<ModelIOPluginController> {
     let package = "plugin_wasm_test_model_minimum";
     let (ty, flag) = build_type_and_flags();
-    inner_create_controller(pipe, &format!("target/wasm32-wasi/{}/{}.wasm", ty, package))
+    inner_create_controller(pipe, &format!("target/wasm32-wasi/{ty}/{package}.wasm"))
         .with_context(|| {
             format!(
-                "try build with \"cargo build --package {} --target wasm32-wasi{}\"",
-                package, flag
+                "try build with \"cargo build --package {package} --target wasm32-wasi{flag}\""
             )
         })
 }

--- a/rust/plugin_wasm/src/model/test/mod.rs
+++ b/rust/plugin_wasm/src/model/test/mod.rs
@@ -84,7 +84,7 @@ fn from_path() -> Result<()> {
     let path = current_dir()?
         .parent()
         .unwrap()
-        .join(format!("target/wasm32-wasi/{}/deps", ty));
+        .join(format!("target/wasm32-wasi/{ty}/deps"));
     let mut controller = ModelIOPluginController::from_path(&path)?;
     let mut names = vec![];
     for plugin in controller.all_plugins_mut() {

--- a/rust/plugin_wasm/src/motion/test/full.rs
+++ b/rust/plugin_wasm/src/motion/test/full.rs
@@ -23,11 +23,10 @@ use super::build_type_and_flags;
 fn create_controller(pipe: &mut Pipe) -> Result<MotionIOPluginController> {
     let package = "plugin_wasm_test_motion_full";
     let (ty, flag) = build_type_and_flags();
-    inner_create_controller(pipe, &format!("target/wasm32-wasi/{}/{}.wasm", ty, package))
+    inner_create_controller(pipe, &format!("target/wasm32-wasi/{ty}/{package}.wasm"))
         .with_context(|| {
             format!(
-                "try build with \"cargo build --package {} --target wasm32-wasi{}\"",
-                package, flag
+                "try build with \"cargo build --package {package} --target wasm32-wasi{flag}\"",
             )
         })
 }

--- a/rust/plugin_wasm/src/motion/test/minimum.rs
+++ b/rust/plugin_wasm/src/motion/test/minimum.rs
@@ -20,11 +20,10 @@ use super::{build_type_and_flags, inner_create_controller};
 fn create_controller(pipe: &mut Pipe) -> Result<MotionIOPluginController> {
     let package = "plugin_wasm_test_motion_minimum";
     let (ty, flag) = build_type_and_flags();
-    inner_create_controller(pipe, &format!("target/wasm32-wasi/{}/{}.wasm", ty, package))
+    inner_create_controller(pipe, &format!("target/wasm32-wasi/{ty}/{package}.wasm"))
         .with_context(|| {
             format!(
-                "try build with \"cargo build --package {} --target wasm32-wasi{}\"",
-                package, flag
+                "try build with \"cargo build --package {package} --target wasm32-wasi{flag}\"",
             )
         })
 }

--- a/rust/plugin_wasm/src/motion/test/mod.rs
+++ b/rust/plugin_wasm/src/motion/test/mod.rs
@@ -83,7 +83,7 @@ fn from_path() -> Result<()> {
     let path = current_dir()?
         .parent()
         .unwrap()
-        .join(format!("target/wasm32-wasi/{}/deps", ty));
+        .join(format!("target/wasm32-wasi/{ty}/deps"));
     let mut controller = MotionIOPluginController::from_path(&path)?;
     let mut names = vec![];
     for plugin in controller.all_plugins_mut() {

--- a/rust/protobuf/build.rs
+++ b/rust/protobuf/build.rs
@@ -5,5 +5,5 @@ fn main() {
         "{}/../../emapp/resources/protobuf",
         std::env::var("CARGO_MANIFEST_DIR").unwrap()
     );
-    prost_build::compile_protos(&[format!("{}/plugin.proto", base)], &[base.to_owned()]).unwrap()
+    prost_build::compile_protos(&[format!("{base}/plugin.proto")], &[base.to_owned()]).unwrap()
 }


### PR DESCRIPTION
## Summary

This PR fixes all clippy warnings caused upgrading Rust 1.67.

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
