### PR TITLE
[rust] bumps Rust edition to `2021` from `2018`

### DIFF
--- a/rust/plugin_wasm/Cargo.toml
+++ b/rust/plugin_wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "plugin_wasm"
 version = "35.0.0"
 authors = ["hkrn <129939+hkrn@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]

--- a/rust/plugin_wasm_test_model_full/Cargo.toml
+++ b/rust/plugin_wasm_test_model_full/Cargo.toml
@@ -2,7 +2,7 @@
 name = "plugin_wasm_test_model_full"
 version = "35.0.0"
 authors = ["hkrn <129939+hkrn@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/rust/plugin_wasm_test_model_minimum/Cargo.toml
+++ b/rust/plugin_wasm_test_model_minimum/Cargo.toml
@@ -2,7 +2,7 @@
 name = "plugin_wasm_test_model_minimum"
 version = "35.0.0"
 authors = ["hkrn <129939+hkrn@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/rust/plugin_wasm_test_motion_full/Cargo.toml
+++ b/rust/plugin_wasm_test_motion_full/Cargo.toml
@@ -2,7 +2,7 @@
 name = "plugin_wasm_test_motion_full"
 version = "35.0.0"
 authors = ["hkrn <129939+hkrn@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/rust/plugin_wasm_test_motion_minimum/Cargo.toml
+++ b/rust/plugin_wasm_test_motion_minimum/Cargo.toml
@@ -2,7 +2,7 @@
 name = "plugin_wasm_test_motion_minimum"
 version = "35.0.0"
 authors = ["hkrn <129939+hkrn@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/rust/protobuf/Cargo.toml
+++ b/rust/protobuf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nanoem-protobuf"
 version = "35.0.0"
 authors = ["hkrn <129939+hkrn@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
## Summary

This PR bumps Rust edition to latest `2021` from `2018`. c.f. [Rust 2021](https://doc.rust-lang.org/edition-guide/rust-2021/index.html#rust-2021)

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
