### PR TITLE
[rust] replaces `assert!` + `is_ok` to `assert_matches!`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -35,6 +35,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-trait"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +758,7 @@ name = "plugin_wasm"
 version = "35.0.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "maplit",
  "nanoem-protobuf",
  "pretty_assertions",

--- a/rust/plugin_wasm/Cargo.toml
+++ b/rust/plugin_wasm/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1"
 maplit = "1"
 rand = "0.8"
 pretty_assertions = "1"
+assert_matches = "1"
 
 [lib]
 path = "src/lib.rs"

--- a/rust/plugin_wasm/src/model/test/full.rs
+++ b/rust/plugin_wasm/src/model/test/full.rs
@@ -5,6 +5,7 @@
 */
 
 use anyhow::{Context, Result};
+use assert_matches::assert_matches;
 use maplit::hashmap;
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -20,12 +21,9 @@ use super::{build_type_and_flags, inner_create_controller};
 fn create_controller(pipe: &mut Pipe) -> Result<ModelIOPluginController> {
     let package = "plugin_wasm_test_model_full";
     let (ty, flag) = build_type_and_flags();
-    inner_create_controller(pipe, &format!("target/wasm32-wasi/{ty}/{package}.wasm"))
-        .with_context(|| {
-            format!(
-                "try build with \"cargo build --package {package} --target wasm32-wasi{flag}\""
-            )
-        })
+    inner_create_controller(pipe, &format!("target/wasm32-wasi/{ty}/{package}.wasm")).with_context(
+        || format!("try build with \"cargo build --package {package} --target wasm32-wasi{flag}\""),
+    )
 }
 
 #[test]
@@ -34,8 +32,8 @@ fn create() -> Result<()> {
     let result = create_controller(&mut pipe);
     assert!(result.is_ok());
     let mut controller = result?;
-    assert!(controller.initialize().is_ok());
-    assert!(controller.create().is_ok());
+    assert_matches!(controller.initialize(), Ok(_));
+    assert_matches!(controller.create(), Ok(_));
     assert_eq!(
         vec![
             PluginOutput {
@@ -108,7 +106,7 @@ fn set_language() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_language(0).is_ok());
+    assert_matches!(controller.set_language(0), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginModelIOSetLanguage".to_owned(),
@@ -132,10 +130,10 @@ fn execute() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_input_model_data(&data).is_ok());
-    assert!(controller.execute().is_ok());
+    assert_matches!(controller.set_input_model_data(&data), Ok(_));
+    assert_matches!(controller.execute(), Ok(_));
     let output = controller.get_output_data();
-    assert!(output.is_ok());
+    assert_matches!(output, Ok(_));
     let output_model_data = output?;
     assert_eq!(
         vec![
@@ -184,7 +182,7 @@ fn set_all_selected_vertex_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_vertex_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_vertex_indices(data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginModelIOSetAllSelectedVertexObjectIndices".to_owned(),
@@ -210,7 +208,7 @@ fn set_all_selected_material_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_material_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_material_indices(data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginModelIOSetAllSelectedMaterialObjectIndices"
@@ -237,7 +235,7 @@ fn set_all_selected_bone_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_bone_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_bone_indices(data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginModelIOSetAllSelectedBoneObjectIndices".to_owned(),
@@ -263,7 +261,7 @@ fn set_all_selected_morph_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_morph_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_morph_indices(data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginModelIOSetAllSelectedMorphObjectIndices".to_owned(),
@@ -289,7 +287,7 @@ fn set_all_selected_label_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_label_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_label_indices(data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginModelIOSetAllSelectedLabelObjectIndices".to_owned(),
@@ -315,7 +313,7 @@ fn set_all_selected_rigid_body_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_rigid_body_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_rigid_body_indices(data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginModelIOSetAllSelectedRigidBodyObjectIndices"
@@ -342,7 +340,7 @@ fn set_all_selected_joint_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_joint_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_joint_indices(data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginModelIOSetAllSelectedJointObjectIndices".to_owned(),
@@ -368,7 +366,7 @@ fn set_all_selected_soft_body_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_soft_body_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_soft_body_indices(data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginModelIOSetAllSelectedSoftBodyObjectIndices"
@@ -395,7 +393,7 @@ fn set_audio_description() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_audio_description(&data).is_ok());
+    assert_matches!(controller.set_audio_description(&data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginModelIOSetAudioDescription".to_owned(),
@@ -421,7 +419,7 @@ fn set_audio_data() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_audio_data(&data).is_ok());
+    assert_matches!(controller.set_audio_data(&data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginModelIOSetInputAudioData".to_owned(),
@@ -447,7 +445,7 @@ fn set_camera_description() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_camera_description(&data).is_ok());
+    assert_matches!(controller.set_camera_description(&data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginModelIOSetCameraDescription".to_owned(),
@@ -473,7 +471,7 @@ fn set_light_description() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_light_description(&data).is_ok());
+    assert_matches!(controller.set_light_description(&data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginModelIOSetLightDescription".to_owned(),
@@ -499,14 +497,15 @@ fn ui_window() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.load_ui_window_layout().is_ok());
+    assert_matches!(controller.load_ui_window_layout(), Ok(_));
     let output = controller.get_ui_window_layout();
-    assert!(output.is_ok());
+    assert_matches!(output, Ok(_));
     let output_ui_layout_data = output?;
     let mut reload = false;
-    assert!(controller
-        .set_ui_component_layout("ui_window", &data, &mut reload)
-        .is_ok());
+    assert_matches!(
+        controller.set_ui_component_layout("ui_window", &data, &mut reload),
+        Ok(_)
+    );
     assert_eq!(
         vec![
             PluginOutput {

--- a/rust/plugin_wasm/src/model/test/minimum.rs
+++ b/rust/plugin_wasm/src/model/test/minimum.rs
@@ -5,6 +5,7 @@
 */
 
 use anyhow::{Context, Result};
+use assert_matches::assert_matches;
 use maplit::hashmap;
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -20,12 +21,9 @@ use super::{build_type_and_flags, inner_create_controller};
 fn create_controller(pipe: &mut Pipe) -> Result<ModelIOPluginController> {
     let package = "plugin_wasm_test_model_minimum";
     let (ty, flag) = build_type_and_flags();
-    inner_create_controller(pipe, &format!("target/wasm32-wasi/{ty}/{package}.wasm"))
-        .with_context(|| {
-            format!(
-                "try build with \"cargo build --package {package} --target wasm32-wasi{flag}\""
-            )
-        })
+    inner_create_controller(pipe, &format!("target/wasm32-wasi/{ty}/{package}.wasm")).with_context(
+        || format!("try build with \"cargo build --package {package} --target wasm32-wasi{flag}\""),
+    )
 }
 
 #[test]
@@ -34,8 +32,8 @@ fn create() -> Result<()> {
     let result = create_controller(&mut pipe);
     assert!(result.is_ok());
     let mut controller = result?;
-    assert!(controller.initialize().is_ok());
-    assert!(controller.create().is_ok());
+    assert_matches!(controller.initialize(), Ok(_));
+    assert_matches!(controller.create(), Ok(_));
     assert_eq!(
         vec![
             PluginOutput {
@@ -98,7 +96,7 @@ fn set_language() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_language(0).is_ok());
+    assert_matches!(controller.set_language(0), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginModelIOSetLanguage".to_owned(),
@@ -122,10 +120,10 @@ fn execute() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_input_model_data(&data).is_ok());
-    assert!(controller.execute().is_ok());
+    assert_matches!(controller.set_input_model_data(&data), Ok(_));
+    assert_matches!(controller.execute(), Ok(_));
     let output = controller.get_output_data();
-    assert!(output.is_ok());
+    assert_matches!(output, Ok(_));
     let output_model_data = output?;
     assert_eq!(
         vec![
@@ -174,7 +172,7 @@ fn set_all_selected_vertex_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_vertex_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_vertex_indices(data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -190,7 +188,7 @@ fn set_all_selected_material_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_material_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_material_indices(data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -206,7 +204,7 @@ fn set_all_selected_bone_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_bone_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_bone_indices(data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -222,7 +220,7 @@ fn set_all_selected_morph_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_morph_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_morph_indices(data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -238,7 +236,7 @@ fn set_all_selected_label_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_label_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_label_indices(data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -254,7 +252,7 @@ fn set_all_selected_rigid_body_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_rigid_body_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_rigid_body_indices(data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -270,7 +268,7 @@ fn set_all_selected_joint_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_joint_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_joint_indices(data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -286,7 +284,7 @@ fn set_all_selected_soft_body_indices() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_soft_body_indices(data).is_ok());
+    assert_matches!(controller.set_all_selected_soft_body_indices(data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -302,7 +300,7 @@ fn set_audio_description() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_audio_description(&data).is_ok());
+    assert_matches!(controller.set_audio_description(&data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -318,7 +316,7 @@ fn set_audio_data() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_audio_data(&data).is_ok());
+    assert_matches!(controller.set_audio_data(&data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -334,7 +332,7 @@ fn set_camera_description() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_camera_description(&data).is_ok());
+    assert_matches!(controller.set_camera_description(&data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -350,7 +348,7 @@ fn set_light_description() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_light_description(&data).is_ok());
+    assert_matches!(controller.set_light_description(&data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -366,14 +364,15 @@ fn ui_window() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.load_ui_window_layout().is_ok());
+    assert_matches!(controller.load_ui_window_layout(), Ok(_));
     let output = controller.get_ui_window_layout();
-    assert!(output.is_ok());
+    assert_matches!(output, Ok(_));
     assert!(output?.is_empty());
     let mut reload = false;
-    assert!(controller
-        .set_ui_component_layout("ui_window", &data, &mut reload)
-        .is_ok());
+    assert_matches!(
+        controller.set_ui_component_layout("ui_window", &data, &mut reload),
+        Ok(_)
+    );
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();

--- a/rust/plugin_wasm/src/motion/test/full.rs
+++ b/rust/plugin_wasm/src/motion/test/full.rs
@@ -5,6 +5,7 @@
 */
 
 use anyhow::{Context, Result};
+use assert_matches::assert_matches;
 use maplit::hashmap;
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -37,8 +38,8 @@ fn create() -> Result<()> {
     let result = create_controller(&mut pipe);
     assert!(result.is_ok());
     let mut controller = result?;
-    assert!(controller.initialize().is_ok());
-    assert!(controller.create().is_ok());
+    assert_matches!(controller.initialize(), Ok(_));
+    assert_matches!(controller.create(), Ok(_));
     assert_eq!(
         vec![
             PluginOutput {
@@ -111,7 +112,7 @@ fn set_language() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_language(0).is_ok());
+    assert_matches!(controller.set_language(0), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginMotionIOSetLanguage".to_owned(),
@@ -135,11 +136,11 @@ fn execute() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_input_model_data(&data).is_ok());
-    assert!(controller.set_input_motion_data(&data).is_ok());
-    assert!(controller.execute().is_ok());
+    assert_matches!(controller.set_input_model_data(&data), Ok(_));
+    assert_matches!(controller.set_input_motion_data(&data), Ok(_));
+    assert_matches!(controller.execute(), Ok(_));
     let output = controller.get_output_data();
-    assert!(output.is_ok());
+    assert_matches!(output, Ok(_));
     let output_motion_data = output?;
     assert_eq!(
         vec![
@@ -196,9 +197,7 @@ fn set_all_selected_accessory_keyframes() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller
-        .set_all_selected_accessory_keyframes(data)
-        .is_ok());
+    assert_matches!(controller.set_all_selected_accessory_keyframes(data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginMotionIOSetAllSelectedAccessoryKeyframes".to_owned(),
@@ -224,7 +223,7 @@ fn set_all_selected_camera_keyframes() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_camera_keyframes(data).is_ok());
+    assert_matches!(controller.set_all_selected_camera_keyframes(data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginMotionIOSetAllSelectedCameraKeyframes".to_owned(),
@@ -250,7 +249,7 @@ fn set_all_selected_light_keyframes() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_light_keyframes(data).is_ok());
+    assert_matches!(controller.set_all_selected_light_keyframes(data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginMotionIOSetAllSelectedLightKeyframes".to_owned(),
@@ -276,7 +275,7 @@ fn set_all_selected_model_keyframes() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_model_keyframes(data).is_ok());
+    assert_matches!(controller.set_all_selected_model_keyframes(data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginMotionIOSetAllSelectedModelKeyframes".to_owned(),
@@ -388,7 +387,7 @@ fn set_audio_description() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_audio_description(&data).is_ok());
+    assert_matches!(controller.set_audio_description(&data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginMotionIOSetAudioDescription".to_owned(),
@@ -414,7 +413,7 @@ fn set_audio_data() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_audio_data(&data).is_ok());
+    assert_matches!(controller.set_audio_data(&data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginMotionIOSetInputAudioData".to_owned(),
@@ -440,7 +439,7 @@ fn set_camera_description() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_camera_description(&data).is_ok());
+    assert_matches!(controller.set_camera_description(&data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginMotionIOSetCameraDescription".to_owned(),
@@ -466,7 +465,7 @@ fn set_light_description() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_light_description(&data).is_ok());
+    assert_matches!(controller.set_light_description(&data), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginMotionIOSetLightDescription".to_owned(),
@@ -492,9 +491,9 @@ fn ui_window() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.load_ui_window_layout().is_ok());
+    assert_matches!(controller.load_ui_window_layout(), Ok(_));
     let output = controller.get_ui_window_layout();
-    assert!(output.is_ok());
+    assert_matches!(output, Ok(_));
     let output_ui_layout_data = output?;
     let mut reload = false;
     assert!(controller

--- a/rust/plugin_wasm/src/motion/test/minimum.rs
+++ b/rust/plugin_wasm/src/motion/test/minimum.rs
@@ -5,6 +5,7 @@
 */
 
 use anyhow::{Context, Result};
+use assert_matches::assert_matches;
 use maplit::hashmap;
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -34,8 +35,8 @@ fn create() -> Result<()> {
     let result = create_controller(&mut pipe);
     assert!(result.is_ok());
     let mut controller = result?;
-    assert!(controller.initialize().is_ok());
-    assert!(controller.create().is_ok());
+    assert_matches!(controller.initialize(), Ok(_));
+    assert_matches!(controller.create(), Ok(_));
     assert_eq!(
         vec![
             PluginOutput {
@@ -98,7 +99,7 @@ fn set_language() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_language(0).is_ok());
+    assert_matches!(controller.set_language(0), Ok(_));
     assert_eq!(
         vec![PluginOutput {
             function: "nanoemApplicationPluginMotionIOSetLanguage".to_owned(),
@@ -122,11 +123,11 @@ fn execute() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_input_model_data(&data).is_ok());
-    assert!(controller.set_input_motion_data(&data).is_ok());
-    assert!(controller.execute().is_ok());
+    assert_matches!(controller.set_input_model_data(&data), Ok(_));
+    assert_matches!(controller.set_input_motion_data(&data), Ok(_));
+    assert_matches!(controller.execute(), Ok(_));
     let output = controller.get_output_data();
-    assert!(output.is_ok());
+    assert_matches!(output, Ok(_));
     let output_motion_data = output?;
     assert_eq!(
         vec![
@@ -175,9 +176,7 @@ fn set_all_selected_accessory_keyframes() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller
-        .set_all_selected_accessory_keyframes(data)
-        .is_ok());
+    assert_matches!(controller.set_all_selected_accessory_keyframes(data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -193,7 +192,7 @@ fn set_all_selected_camera_keyframes() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_camera_keyframes(data).is_ok());
+    assert_matches!(controller.set_all_selected_camera_keyframes(data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -209,7 +208,7 @@ fn set_all_selected_light_keyframes() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_light_keyframes(data).is_ok());
+    assert_matches!(controller.set_all_selected_light_keyframes(data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -225,7 +224,7 @@ fn set_all_selected_model_keyframes() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_all_selected_model_keyframes(data).is_ok());
+    assert_matches!(controller.set_all_selected_model_keyframes(data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -295,7 +294,7 @@ fn set_audio_description() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_audio_description(&data).is_ok());
+    assert_matches!(controller.set_audio_description(&data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -311,7 +310,7 @@ fn set_audio_data() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_audio_data(&data).is_ok());
+    assert_matches!(controller.set_audio_data(&data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -327,7 +326,7 @@ fn set_camera_description() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_camera_description(&data).is_ok());
+    assert_matches!(controller.set_camera_description(&data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -343,7 +342,7 @@ fn set_light_description() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.set_light_description(&data).is_ok());
+    assert_matches!(controller.set_light_description(&data), Ok(_));
     assert!(read_plugin_output(&mut pipe)?.is_empty());
     controller.destroy();
     controller.terminate();
@@ -359,9 +358,9 @@ fn ui_window() -> Result<()> {
     controller.create()?;
     controller.set_function(0)?;
     flush_plugin_output(&mut pipe)?;
-    assert!(controller.load_ui_window_layout().is_ok());
+    assert_matches!(controller.load_ui_window_layout(), Ok(_));
     let output = controller.get_ui_window_layout();
-    assert!(output.is_ok());
+    assert_matches!(output, Ok(_));
     assert!(output?.is_empty());
     let mut reload = false;
     assert!(controller


### PR DESCRIPTION
## Summary

This PR replaces `assert!` + `is_ok` to `assert_matches!` using [assert_matches](https://crates.io/crates/assert_matches) crate.

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
