### PR TITLE
[emapp] fixed a bug of loading the texture with ambiguous path

### DIFF
--- a/emapp/include/emapp/Model.h
+++ b/emapp/include/emapp/Model.h
@@ -436,7 +436,7 @@ private:
     struct LoadingImageItem;
     typedef tinystl::vector<sg::LineVertexUnit, TinySTLAllocator> LineVertexList;
     typedef tinystl::vector<LoadingImageItem *, TinySTLAllocator> LoadingImageItemList;
-    typedef tinystl::unordered_map<String, Image *, TinySTLAllocator> ImageMap;
+    typedef tinystl::unordered_map<URI, Image *, TinySTLAllocator> ImageMap;
     typedef tinystl::unordered_map<String, const nanoem_model_bone_t *, TinySTLAllocator> BoneHashMap;
     typedef tinystl::unordered_map<String, const nanoem_model_morph_t *, TinySTLAllocator> MorphHashMap;
     typedef tinystl::unordered_map<const nanoem_model_bone_t *, const nanoem_model_constraint_t *, TinySTLAllocator>

--- a/emapp/include/emapp/URI.h
+++ b/emapp/include/emapp/URI.h
@@ -36,12 +36,16 @@ public:
     String lastPathComponent() const;
     const char *lastPathComponentConstString() const NANOEM_DECL_NOEXCEPT;
     String pathExtension() const;
+    nanoem_u32_t hash() const NANOEM_DECL_NOEXCEPT;
     bool isEmpty() const NANOEM_DECL_NOEXCEPT;
     bool hasFragment() const;
     bool equalsTo(const URI &other) const NANOEM_DECL_NOEXCEPT;
     bool equalsToAbsolutePath(const String &other) const NANOEM_DECL_NOEXCEPT;
     bool equalsToAbsolutePathConstString(const char *other) const NANOEM_DECL_NOEXCEPT;
     bool equalsToFilenameConstString(const char *other) const NANOEM_DECL_NOEXCEPT;
+
+    bool operator==(const URI &value) const NANOEM_DECL_NOEXCEPT;
+    operator size_t() const NANOEM_DECL_NOEXCEPT { return hash(); }
 
 private:
     URI(const String &path, const String &fragment);

--- a/emapp/src/URI.cc
+++ b/emapp/src/URI.cc
@@ -8,6 +8,8 @@
 
 #include "emapp/StringUtils.h"
 
+#include "bx/hash.h"
+
 namespace nanoem {
 
 String
@@ -145,6 +147,16 @@ URI::pathExtension() const
     return pathExtension(m_absolutePath);
 }
 
+nanoem_u32_t
+URI::hash() const NANOEM_DECL_NOEXCEPT
+{
+    bx::HashMurmur2A hasher;
+    hasher.begin();
+    hasher.add(m_absolutePath.c_str(), m_absolutePath.size());
+    hasher.add(m_fragment.c_str(), m_fragment.size());
+    return hasher.end();
+}
+
 bool
 URI::isEmpty() const NANOEM_DECL_NOEXCEPT
 {
@@ -180,6 +192,13 @@ URI::equalsToFilenameConstString(const char *other) const NANOEM_DECL_NOEXCEPT
 {
     const char *p = lastPathComponentConstString(m_absolutePath);
     return p ? StringUtils::equalsIgnoreCase(p, other) : false;
+}
+
+bool
+URI::operator==(const URI &value) const NANOEM_DECL_NOEXCEPT
+{
+    return StringUtils::equals(absolutePathConstString(), value.absolutePathConstString()) &&
+            StringUtils::equals(fragmentConstString(), value.fragmentConstString());
 }
 
 URI::URI(const String &path, const String &fragment)


### PR DESCRIPTION
## Summary

The PR fixes a bug of loading the texture with ambiguous path such as `texture.png` and `./texture.png` in the same model.

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
