### PR TITLE
[rust] fix `rust/scripts/build.bat` to be runnable

### DIFF
--- a/rust/scripts/build.bat
+++ b/rust/scripts/build.bat
@@ -6,10 +6,10 @@ set packages=plugin_wasm_test_model_minimum plugin_wasm_test_motion_minimum plug
 rustup target add wasm32-wasi
 cargo install cargo-deny
 cargo deny check
-for %%profile in %profiles%
-  for %%package in %packages%
-    cargo build --profile %%profile --package %%package --target wasm32-wasi
-  done
-done
+for %%i in (%profiles%) do (
+  for %%j in (%packages%) do (
+    cargo build --profile %%i --package %%j --target wasm32-wasi
+  )
+)
 cargo build --profile release-lto
 cargo test --profile release-lto


### PR DESCRIPTION
## Summary

This PR fixes `rust/scripts/build.bat` due to commit without run.

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
