### PR TITLE
[github] bumps `actions/checkout` to v4 and `actions/labeler` to v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,11 +1,21 @@
-docs: docs/**/*
+docs:
+  - changed-files:
+    - any-glob-to-any-file: docs/**
 emapp:
-- emapp/**/*
-- glfw/**/*
-- macos/**/*
-- sandbox/**/*
-- sapp/**/*
-- win32/**/*
-github: .github/**/*
-nanoem: nanoem/**/*
-rust: rust/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - emapp/**
+      - glfw/**
+      - macos/**
+      - sandbox/**
+      - sapp/**
+      - win32/**
+github:
+  - changed-files:
+    - any-glob-to-any-file: .github/**
+nanoem:
+  - changed-files:
+    - any-glob-to-any-file: nanoem/**
+rust:
+  - changed-files:
+    - any-glob-to-any-file: rust/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       LDFLAGS: -lc++abi
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       # Assumes clang/cmake/libc++/libc++abi are installed on GitHub Actions Runner
@@ -86,7 +86,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: checkout ffmpeg
@@ -131,7 +131,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -174,7 +174,7 @@ jobs:
         working-directory: ${{ github.workspace }}/rust
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup prerequisite packages
         run: |
           sudo apt-get update && sudo apt-get install -y \
@@ -191,7 +191,7 @@ jobs:
       NANOEM_BUILD_DEPENDENCIES_DIRECTORY: ${{ github.workspace }}/out/dependencies
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: initialize CodeQL


### PR DESCRIPTION
## Summary

This PR bumps following GitHub Actions modules to prevent NodeJS warnings.

- [actions/checkout](https://github.com/actions/checkout) to v4
- [actions/labeler](https://github.com/actions/labeler) to v5

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
