### PR TITLE
[docs] adds `requirements.txt` to fix building document error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,5 +14,9 @@ formats: all
 sphinx:
   configuration: docs/conf.py
 
+python:
+  install:
+  - requirements: docs/requirements.txt
+
 submodules:
   exclude: all

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-rtd-theme ~= 2.0


### PR DESCRIPTION
## Summary

This PR adds `requirements.txt` to fix building document error from 2023/10/9 (https://github.com/hkrn/nanoem/commit/d0a14eb5820670f800d8ff9a33260f96069374ff)

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
