### PR TITLE
[rust] remove warnings of upcoming rust edition 2024

### DIFF
--- a/rust/plugin_wasm/src/lib.rs
+++ b/rust/plugin_wasm/src/lib.rs
@@ -33,9 +33,9 @@ pub enum nanoem_application_plugin_status_t {
 }
 
 impl nanoem_application_plugin_status_t {
-    pub(crate) unsafe fn assign(self, value: *mut nanoem_application_plugin_status_t) {
+    pub(crate) fn assign(self, value: *mut nanoem_application_plugin_status_t) {
         if !value.is_null() {
-            *value = self;
+            unsafe { *value = self };
         }
     }
 }

--- a/rust/plugin_wasm/src/model/c_api.rs
+++ b/rust/plugin_wasm/src/model/c_api.rs
@@ -36,7 +36,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOInitialize() {
 #[no_mangle]
 pub unsafe extern "C" fn nanoemApplicationPluginModelIOCreate(
 ) -> *mut nanoem_application_plugin_model_io_t {
-    nanoemApplicationPluginModelIOCreateWithLocation(null())
+    unsafe { nanoemApplicationPluginModelIOCreateWithLocation(null()) }
 }
 
 /// # Safety
@@ -46,12 +46,12 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOCreate(
 pub unsafe extern "C" fn nanoemApplicationPluginModelIOCreateWithLocation(
     path: *const c_char,
 ) -> *mut nanoem_application_plugin_model_io_t {
-    let path = CStr::from_ptr(path as *const c_char);
+    let path = unsafe { CStr::from_ptr(path as *const c_char) };
     if let Ok(mut instance) = nanoem_application_plugin_model_io_t::new(path) {
         let result = instance.create();
         if result.is_ok() {
             let plugin = Box::new(instance);
-            return std::mem::transmute(plugin);
+            return unsafe { std::mem::transmute(plugin) };
         }
     }
     null_mut()
@@ -168,7 +168,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetAllSelectedVertexObjec
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !data.is_null() && length > 0 {
-                std::slice::from_raw_parts(data, length as usize)
+                unsafe { std::slice::from_raw_parts(data, length as usize) }
             } else {
                 &[]
             };
@@ -195,7 +195,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetAllSelectedMaterialObj
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !data.is_null() && length > 0 {
-                std::slice::from_raw_parts(data, length as usize)
+                unsafe { std::slice::from_raw_parts(data, length as usize) }
             } else {
                 &[]
             };
@@ -222,7 +222,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetAllSelectedBoneObjectI
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !data.is_null() && length > 0 {
-                std::slice::from_raw_parts(data, length as usize)
+                unsafe { std::slice::from_raw_parts(data, length as usize) }
             } else {
                 &[]
             };
@@ -249,7 +249,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetAllSelectedConstraintO
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !data.is_null() && length > 0 {
-                std::slice::from_raw_parts(data, length as usize)
+                unsafe { std::slice::from_raw_parts(data, length as usize) }
             } else {
                 &[]
             };
@@ -276,7 +276,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetAllSelectedMorphObject
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !data.is_null() && length > 0 {
-                std::slice::from_raw_parts(data, length as usize)
+                unsafe { std::slice::from_raw_parts(data, length as usize) }
             } else {
                 &[]
             };
@@ -303,7 +303,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetAllSelectedLabelObject
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !data.is_null() && length > 0 {
-                std::slice::from_raw_parts(data, length as usize)
+                unsafe { std::slice::from_raw_parts(data, length as usize) }
             } else {
                 &[]
             };
@@ -330,7 +330,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetAllSelectedRigidBodyOb
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !data.is_null() && length > 0 {
-                std::slice::from_raw_parts(data, length as usize)
+                unsafe { std::slice::from_raw_parts(data, length as usize) }
             } else {
                 &[]
             };
@@ -357,7 +357,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetAllSelectedJointObject
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !data.is_null() && length > 0 {
-                std::slice::from_raw_parts(data, length as usize)
+                unsafe { std::slice::from_raw_parts(data, length as usize) }
             } else {
                 &[]
             };
@@ -384,7 +384,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetAllSelectedSoftBodyObj
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !data.is_null() && length > 0 {
-                std::slice::from_raw_parts(data, length as usize)
+                unsafe { std::slice::from_raw_parts(data, length as usize) }
             } else {
                 &[]
             };
@@ -411,7 +411,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetAudioDescription(
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
         Some(instance) => {
             if !data.is_null() && length > 0 {
-                let slice = std::slice::from_raw_parts(data, length as usize);
+                let slice = unsafe { std::slice::from_raw_parts(data, length as usize) };
                 match instance.set_audio_description(slice) {
                     Ok(_) => nanoem_application_plugin_status_t::SUCCESS,
                     Err(value) => instance.assign_failure_reason(value),
@@ -438,7 +438,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetCameraDescription(
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
         Some(instance) => {
             if !data.is_null() && length > 0 {
-                let slice = std::slice::from_raw_parts(data, length as usize);
+                let slice = unsafe { std::slice::from_raw_parts(data, length as usize) };
                 match instance.set_camera_description(slice) {
                     Ok(_) => nanoem_application_plugin_status_t::SUCCESS,
                     Err(value) => instance.assign_failure_reason(value),
@@ -465,7 +465,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetLightDescription(
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
         Some(instance) => {
             if !data.is_null() && length > 0 {
-                let slice = std::slice::from_raw_parts(data, length as usize);
+                let slice = unsafe { std::slice::from_raw_parts(data, length as usize) };
                 match instance.set_light_description(slice) {
                     Ok(_) => nanoem_application_plugin_status_t::SUCCESS,
                     Err(value) => instance.assign_failure_reason(value),
@@ -492,7 +492,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetInputAudioData(
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
         Some(instance) => {
             if !data.is_null() && length > 0 {
-                let slice = std::slice::from_raw_parts(data, length as usize);
+                let slice = unsafe { std::slice::from_raw_parts(data, length as usize) };
                 match instance.set_audio_data(slice) {
                     Ok(_) => nanoem_application_plugin_status_t::SUCCESS,
                     Err(value) => instance.assign_failure_reason(value),
@@ -519,7 +519,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetInputModelData(
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
         Some(instance) => {
             if !data.is_null() && length > 0 {
-                let slice = std::slice::from_raw_parts(data, length as usize);
+                let slice = unsafe { std::slice::from_raw_parts(data, length as usize) };
                 match instance.set_input_data(slice) {
                     Ok(_) => nanoem_application_plugin_status_t::SUCCESS,
                     Err(value) => instance.assign_failure_reason(value),
@@ -561,7 +561,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOGetOutputModelDataSize(
 ) {
     if let Some(instance) = nanoem_application_plugin_model_io_t::get_mut(plugin) {
         if !length.is_null() {
-            *length = instance.output_slice().len() as u32
+            unsafe { *length = instance.output_slice().len() as u32 }
         }
     }
 }
@@ -580,11 +580,13 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOGetOutputModelData(
         Some(instance) => {
             if !data.is_null() && length > 0 {
                 let slice = instance.output_slice();
-                std::ptr::copy(
-                    slice.as_ptr(),
-                    data,
-                    std::cmp::min(length as usize, slice.len()),
-                );
+                unsafe {
+                    std::ptr::copy(
+                        slice.as_ptr(),
+                        data,
+                        std::cmp::min(length as usize, slice.len()),
+                    )
+                };
                 nanoem_application_plugin_status_t::SUCCESS
             } else {
                 nanoem_application_plugin_status_t::ERROR_NULL_OBJECT
@@ -623,7 +625,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOGetUIWindowLayoutDataSize
 ) {
     if let Some(instance) = nanoem_application_plugin_model_io_t::get_mut(plugin) {
         if !length.is_null() {
-            *length = instance.window_layout_data_slice().len() as u32
+            unsafe { *length = instance.window_layout_data_slice().len() as u32 }
         }
     }
 }
@@ -642,11 +644,13 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOGetUIWindowLayoutData(
         Some(instance) => {
             if !data.is_null() && length > 0 {
                 let slice = instance.window_layout_data_slice();
-                std::ptr::copy(
-                    slice.as_ptr(),
-                    data,
-                    std::cmp::min(length as usize, slice.len()),
-                );
+                unsafe {
+                    std::ptr::copy(
+                        slice.as_ptr(),
+                        data,
+                        std::cmp::min(length as usize, slice.len()),
+                    )
+                };
                 nanoem_application_plugin_status_t::SUCCESS
             } else {
                 nanoem_application_plugin_status_t::ERROR_NULL_OBJECT
@@ -670,7 +674,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetUIComponentLayoutData(
     status_ptr: *mut nanoem_application_plugin_status_t,
 ) {
     let status = match nanoem_application_plugin_model_io_t::get_mut(plugin) {
-        Some(instance) => {
+        Some(instance) => unsafe {
             let id = CStr::from_ptr(id as *const c_char);
             let data = std::slice::from_raw_parts(data, length as usize);
             let mut reload = false;
@@ -683,7 +687,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOSetUIComponentLayoutData(
                 }
                 Err(value) => instance.assign_failure_reason(value),
             }
-        }
+        },
         None => nanoem_application_plugin_status_t::ERROR_NULL_OBJECT,
     };
     status.assign(status_ptr)
@@ -729,7 +733,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIODestroy(
     plugin: *mut nanoem_application_plugin_model_io_t,
 ) {
     if !plugin.is_null() {
-        let _: Box<nanoem_application_plugin_model_io_t> = std::mem::transmute(plugin);
+        let _: Box<nanoem_application_plugin_model_io_t> = unsafe { std::mem::transmute(plugin) };
     }
 }
 

--- a/rust/plugin_wasm/src/model/core.rs
+++ b/rust/plugin_wasm/src/model/core.rs
@@ -36,16 +36,16 @@ impl nanoem_application_plugin_model_io_t {
         controller.initialize()?;
         Ok(Self { controller })
     }
-    pub(crate) unsafe fn get(plugin: *const Self) -> Option<&'static Self> {
+    pub(crate) fn get(plugin: *const Self) -> Option<&'static Self> {
         if !plugin.is_null() {
-            Some(&(*plugin))
+            Some(unsafe { &(*plugin) })
         } else {
             None
         }
     }
-    pub(crate) unsafe fn get_mut(plugin: *mut Self) -> Option<&'static mut Self> {
+    pub(crate) fn get_mut(plugin: *mut Self) -> Option<&'static mut Self> {
         if !plugin.is_null() {
-            Some(&mut (*plugin))
+            Some(unsafe { &mut (*plugin) })
         } else {
             None
         }

--- a/rust/plugin_wasm/src/model/test/mod.rs
+++ b/rust/plugin_wasm/src/model/test/mod.rs
@@ -19,7 +19,10 @@ use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use wasi_common::{
-    file::{FileType, Filestat}, snapshots::preview_1::types::Error, sync::WasiCtxBuilder, WasiFile
+    file::{FileType, Filestat},
+    snapshots::preview_1::types::Error,
+    sync::WasiCtxBuilder,
+    WasiFile,
 };
 use wasmtime::{Engine, Linker};
 
@@ -100,7 +103,7 @@ fn create_random_data(size: usize) -> Vec<u8> {
     let mut data = vec![];
     let mut rng = thread_rng();
     for _ in 0..size {
-        let v: u8 = rng.gen();
+        let v: u8 = rng.r#gen();
         data.push(v);
     }
     data

--- a/rust/plugin_wasm/src/motion/c_api.rs
+++ b/rust/plugin_wasm/src/motion/c_api.rs
@@ -36,7 +36,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOInitialize() {
 #[no_mangle]
 pub unsafe extern "C" fn nanoemApplicationPluginMotionIOCreate(
 ) -> *mut nanoem_application_plugin_motion_io_t {
-    nanoemApplicationPluginMotionIOCreateWithLocation(null())
+    unsafe { nanoemApplicationPluginMotionIOCreateWithLocation(null()) }
 }
 
 /// # Safety
@@ -46,12 +46,12 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOCreate(
 pub unsafe extern "C" fn nanoemApplicationPluginMotionIOCreateWithLocation(
     path: *const c_char,
 ) -> *mut nanoem_application_plugin_motion_io_t {
-    let path = CStr::from_ptr(path as *const c_char);
+    let path = unsafe { CStr::from_ptr(path as *const c_char) };
     if let Ok(mut instance) = nanoem_application_plugin_motion_io_t::new(path) {
         let result = instance.create();
         if result.is_ok() {
             let plugin = Box::new(instance);
-            return std::mem::transmute(plugin);
+            return unsafe { std::mem::transmute(plugin) };
         }
     }
     null_mut()
@@ -169,13 +169,14 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetAllNamedSelectedBoneK
     let status = match nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !frame_indices.is_null() && length > 0 {
-                std::slice::from_raw_parts(frame_indices, length as usize)
+                unsafe { std::slice::from_raw_parts(frame_indices, length as usize) }
             } else {
                 &[]
             };
-            match instance
-                .set_all_named_selected_bone_keyframes(CStr::from_ptr(name as *const c_char), slice)
-            {
+            match instance.set_all_named_selected_bone_keyframes(
+                unsafe { CStr::from_ptr(name as *const c_char) },
+                slice,
+            ) {
                 Ok(_) => nanoem_application_plugin_status_t::SUCCESS,
                 Err(value) => instance.assign_failure_reason(value),
             }
@@ -199,12 +200,12 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetAllNamedSelectedMorph
     let status = match nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !frame_indices.is_null() && length > 0 {
-                std::slice::from_raw_parts(frame_indices, length as usize)
+                unsafe { std::slice::from_raw_parts(frame_indices, length as usize) }
             } else {
                 &[]
             };
             match instance.set_all_named_selected_morph_keyframes(
-                CStr::from_ptr(name as *const c_char),
+                unsafe { CStr::from_ptr(name as *const c_char) },
                 slice,
             ) {
                 Ok(_) => nanoem_application_plugin_status_t::SUCCESS,
@@ -229,7 +230,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetAllSelectedAccessoryK
     let status = match nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !frame_indices.is_null() && length > 0 {
-                std::slice::from_raw_parts(frame_indices, length as usize)
+                unsafe { std::slice::from_raw_parts(frame_indices, length as usize) }
             } else {
                 &[]
             };
@@ -256,7 +257,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetAllSelectedCameraKeyf
     let status = match nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !frame_indices.is_null() && length > 0 {
-                std::slice::from_raw_parts(frame_indices, length as usize)
+                unsafe { std::slice::from_raw_parts(frame_indices, length as usize) }
             } else {
                 &[]
             };
@@ -283,7 +284,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetAllSelectedLightKeyfr
     let status = match nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !frame_indices.is_null() && length > 0 {
-                std::slice::from_raw_parts(frame_indices, length as usize)
+                unsafe { std::slice::from_raw_parts(frame_indices, length as usize) }
             } else {
                 &[]
             };
@@ -310,7 +311,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetAllSelectedModelKeyfr
     let status = match nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !frame_indices.is_null() && length > 0 {
-                std::slice::from_raw_parts(frame_indices, length as usize)
+                unsafe { std::slice::from_raw_parts(frame_indices, length as usize) }
             } else {
                 &[]
             };
@@ -337,7 +338,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetAllSelectedSelfShadow
     let status = match nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         Some(instance) => {
             let slice = if !frame_indices.is_null() && length > 0 {
-                std::slice::from_raw_parts(frame_indices, length as usize)
+                unsafe { std::slice::from_raw_parts(frame_indices, length as usize) }
             } else {
                 &[]
             };
@@ -364,7 +365,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetAudioDescription(
     let status = match nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         Some(instance) => {
             if !data.is_null() && length > 0 {
-                let slice = std::slice::from_raw_parts(data, length as usize);
+                let slice = unsafe { std::slice::from_raw_parts(data, length as usize) };
                 match instance.set_audio_description(slice) {
                     Ok(_) => nanoem_application_plugin_status_t::SUCCESS,
                     Err(value) => instance.assign_failure_reason(value),
@@ -391,7 +392,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetCameraDescription(
     let status = match nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         Some(instance) => {
             if !data.is_null() && length > 0 {
-                let slice = std::slice::from_raw_parts(data, length as usize);
+                let slice = unsafe { std::slice::from_raw_parts(data, length as usize) };
                 match instance.set_camera_description(slice) {
                     Ok(_) => nanoem_application_plugin_status_t::SUCCESS,
                     Err(value) => instance.assign_failure_reason(value),
@@ -418,7 +419,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetLightDescription(
     let status = match nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         Some(instance) => {
             if !data.is_null() && length > 0 {
-                let slice = std::slice::from_raw_parts(data, length as usize);
+                let slice = unsafe { std::slice::from_raw_parts(data, length as usize) };
                 match instance.set_light_description(slice) {
                     Ok(_) => nanoem_application_plugin_status_t::SUCCESS,
                     Err(value) => instance.assign_failure_reason(value),
@@ -445,7 +446,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetInputAudioData(
     let status = match nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         Some(instance) => {
             if !data.is_null() && length > 0 {
-                let slice = std::slice::from_raw_parts(data, length as usize);
+                let slice = unsafe { std::slice::from_raw_parts(data, length as usize) };
                 match instance.set_audio_data(slice) {
                     Ok(_) => nanoem_application_plugin_status_t::SUCCESS,
                     Err(value) => instance.assign_failure_reason(value),
@@ -472,7 +473,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetInputMotionData(
     let status = match nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         Some(instance) => {
             if !data.is_null() && length > 0 {
-                let slice = std::slice::from_raw_parts(data, length as usize);
+                let slice = unsafe { std::slice::from_raw_parts(data, length as usize) };
                 match instance.set_input_motion_data(slice) {
                     Ok(_) => nanoem_application_plugin_status_t::SUCCESS,
                     Err(value) => instance.assign_failure_reason(value),
@@ -499,7 +500,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetInputActiveModelData(
     let status = match nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         Some(instance) => {
             if !data.is_null() && length > 0 {
-                let slice = std::slice::from_raw_parts(data, length as usize);
+                let slice = unsafe { std::slice::from_raw_parts(data, length as usize) };
                 match instance.set_input_model_data(slice) {
                     Ok(_) => nanoem_application_plugin_status_t::SUCCESS,
                     Err(value) => instance.assign_failure_reason(value),
@@ -541,7 +542,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOGetOutputMotionDataSize(
 ) {
     if let Some(instance) = nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         if !length.is_null() {
-            *length = instance.output_slice().len() as u32
+            unsafe { *length = instance.output_slice().len() as u32 };
         }
     }
 }
@@ -560,11 +561,13 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOGetOutputMotionData(
         Some(instance) => {
             if !data.is_null() && length > 0 {
                 let slice = instance.output_slice();
-                std::ptr::copy(
-                    slice.as_ptr(),
-                    data,
-                    std::cmp::min(length as usize, slice.len()),
-                );
+                unsafe {
+                    std::ptr::copy(
+                        slice.as_ptr(),
+                        data,
+                        std::cmp::min(length as usize, slice.len()),
+                    )
+                };
                 nanoem_application_plugin_status_t::SUCCESS
             } else {
                 nanoem_application_plugin_status_t::ERROR_NULL_OBJECT
@@ -603,7 +606,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOGetUIWindowLayoutDataSiz
 ) {
     if let Some(instance) = nanoem_application_plugin_motion_io_t::get_mut(plugin) {
         if !length.is_null() {
-            *length = instance.window_layout_data_slice().len() as u32
+            unsafe { *length = instance.window_layout_data_slice().len() as u32 };
         }
     }
 }
@@ -622,11 +625,13 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOGetUIWindowLayoutData(
         Some(instance) => {
             if !data.is_null() && length > 0 {
                 let slice = instance.window_layout_data_slice();
-                std::ptr::copy(
-                    slice.as_ptr(),
-                    data,
-                    std::cmp::min(length as usize, slice.len()),
-                );
+                unsafe {
+                    std::ptr::copy(
+                        slice.as_ptr(),
+                        data,
+                        std::cmp::min(length as usize, slice.len()),
+                    );
+                }
                 nanoem_application_plugin_status_t::SUCCESS
             } else {
                 nanoem_application_plugin_status_t::ERROR_NULL_OBJECT
@@ -650,7 +655,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetUIComponentLayoutData
     status_ptr: *mut nanoem_application_plugin_status_t,
 ) {
     let status = match nanoem_application_plugin_motion_io_t::get_mut(plugin) {
-        Some(instance) => {
+        Some(instance) => unsafe {
             let id = CStr::from_ptr(id as *const c_char);
             let slice = std::slice::from_raw_parts(data, length as usize);
             let mut reload = false;
@@ -663,7 +668,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOSetUIComponentLayoutData
                 }
                 Err(value) => instance.assign_failure_reason(value),
             }
-        }
+        },
         None => nanoem_application_plugin_status_t::ERROR_NULL_OBJECT,
     };
     status.assign(status_ptr)
@@ -709,7 +714,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIODestroy(
     plugin: *mut nanoem_application_plugin_motion_io_t,
 ) {
     if !plugin.is_null() {
-        let _: Box<nanoem_application_plugin_motion_io_t> = std::mem::transmute(plugin);
+        let _: Box<nanoem_application_plugin_motion_io_t> = unsafe { std::mem::transmute(plugin) };
     }
 }
 

--- a/rust/plugin_wasm/src/motion/core.rs
+++ b/rust/plugin_wasm/src/motion/core.rs
@@ -36,16 +36,16 @@ impl nanoem_application_plugin_motion_io_t {
         controller.initialize()?;
         Ok(Self { controller })
     }
-    pub(crate) unsafe fn get(plugin: *const Self) -> Option<&'static Self> {
+    pub(crate) fn get(plugin: *const Self) -> Option<&'static Self> {
         if !plugin.is_null() {
-            Some(&(*plugin))
+            unsafe { Some(&(*plugin)) }
         } else {
             None
         }
     }
-    pub(crate) unsafe fn get_mut(plugin: *mut Self) -> Option<&'static mut Self> {
+    pub(crate) fn get_mut(plugin: *mut Self) -> Option<&'static mut Self> {
         if !plugin.is_null() {
-            Some(&mut (*plugin))
+            unsafe { Some(&mut (*plugin)) }
         } else {
             None
         }

--- a/rust/plugin_wasm/src/motion/test/mod.rs
+++ b/rust/plugin_wasm/src/motion/test/mod.rs
@@ -20,7 +20,10 @@ use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use wasi_common::{
-    file::{FileType, Filestat}, snapshots::preview_1::types::Error, sync::WasiCtxBuilder, WasiFile
+    file::{FileType, Filestat},
+    snapshots::preview_1::types::Error,
+    sync::WasiCtxBuilder,
+    WasiFile,
 };
 use wasmtime::{Engine, Linker};
 
@@ -101,7 +104,7 @@ fn create_random_data(size: usize) -> Vec<u8> {
     let mut data = vec![];
     let mut rng = thread_rng();
     for _ in 0..size {
-        let v: u8 = rng.gen();
+        let v: u8 = rng.r#gen();
         data.push(v);
     }
     data


### PR DESCRIPTION
## Summary

The PR removes warnings of [upcoming Rust edition 2024](https://blog.rust-lang.org/inside-rust/2024/03/22/2024-edition-update.html).

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
