### PR TITLE
[rust] terminate method of plugin instance now takes ownership

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ env:
   ICU_VERSION_TAG: release-71-1
   NANOEM_BUILD_DEPENDENCIES_DIRECTORY: ${{ github.workspace }}/out/dependencies
   NANOEM_BUILD_ARTIFACT_DIRECTORY: ${{ github.workspace }}/out/core
+  NANOEM_RUST_DIRECTORY: ${{ github.workspace }}/rust
 
 jobs:
   build-linux:
@@ -171,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ${{ github.workspace }}/rust
+        working-directory: ${{ env.NANOEM_RUST_DIRECTORY }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -182,10 +183,13 @@ jobs:
       - name: setup rust toolchain (stable and wasm32-wasi)
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache-workspaces: ${{ env.NANOEM_RUST_DIRECTORY }}
           components: rustfmt
           target: wasm32-wasi
       - name: run rustfmt for check
         uses: actions-rust-lang/rustfmt@v1
+        with:
+          manifest-path: ${{ env.NANOEM_RUST_DIRECTORY }}/Cargo.toml
       - name: setup prerequisite packages
         run: |
           sudo apt-get update && sudo apt-get install -y \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,10 +175,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - name: setup prerequisite packages
-        run: |
-          sudo apt-get update && sudo apt-get install -y \
-            protobuf-compiler
       - name: setup cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v1
         with:
@@ -186,7 +182,14 @@ jobs:
       - name: setup rust toolchain (stable and wasm32-wasi)
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          components: rustfmt
           target: wasm32-wasi
+      - name: run rustfmt for check
+        uses: actions-rust-lang/rustfmt@v1
+      - name: setup prerequisite packages
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            protobuf-compiler
       - name: build plugin_wasm and its test WASMs
         run: |
           profiles=('dev' 'release-lto')

--- a/rust/plugin_wasm/src/model/controller.rs
+++ b/rust/plugin_wasm/src/model/controller.rs
@@ -116,13 +116,17 @@ impl ModelIOPluginController {
                     }
                     notify::EventKind::Remove(_) => {
                         let mut guard = plugins_inner.lock();
-                        let indices = guard.iter().enumerate().filter_map(|(i, plugin)| {
-                            if ev.paths.contains(plugin.path()) {
-                                Some(i)
-                            } else {
-                                None
-                            }
-                        }).collect::<Vec<_>>();
+                        let indices = guard
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(i, plugin)| {
+                                if ev.paths.contains(plugin.path()) {
+                                    Some(i)
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<_>>();
                         for index in indices {
                             let mut plugin = guard.remove(index);
                             tracing::info!(

--- a/rust/plugin_wasm/src/model/plugin.rs
+++ b/rust/plugin_wasm/src/model/plugin.rs
@@ -370,7 +370,7 @@ impl ModelIOPlugin {
             &mut self.store,
         )
     }
-    pub fn terminate(&mut self) {
+    pub fn terminate(mut self) {
         inner_terminate_function(
             &self.instance,
             "nanoemApplicationPluginModelIOTerminate",

--- a/rust/plugin_wasm/src/motion/controller.rs
+++ b/rust/plugin_wasm/src/motion/controller.rs
@@ -97,12 +97,11 @@ impl MotionIOPluginController {
                                 match create_plugin(path) {
                                     Ok(plugin) => {
                                         plugin_mut.destroy();
-                                        plugin_mut.terminate();
+                                        std::mem::replace(plugin_mut, plugin).terminate();
                                         tracing::info!(
                                             path = ?path,
                                             "WASM motion I/O plugin is modified and reloaded",
                                         );
-                                        *plugin_mut = plugin
                                     }
                                     Err(err) => {
                                         tracing::warn!(
@@ -116,19 +115,23 @@ impl MotionIOPluginController {
                         }
                     }
                     notify::EventKind::Remove(_) => {
-                        plugins_inner.lock().retain_mut(|plugin| {
+                        let mut guard = plugins_inner.lock();
+                        let indices = guard.iter().enumerate().filter_map(|(i, plugin)| {
                             if ev.paths.contains(plugin.path()) {
-                                plugin.destroy();
-                                plugin.terminate();
-                                tracing::info!(
-                                    path = ?plugin.path(),
-                                    "WASM motion I/O is removed",
-                                );
-                                false
+                                Some(i)
                             } else {
-                                true
+                                None
                             }
-                        });
+                        }).collect::<Vec<_>>();
+                        for index in indices {
+                            let mut plugin = guard.remove(index);
+                            tracing::info!(
+                                path = ?plugin.path(),
+                                "WASM motion I/O is removed",
+                            );
+                            plugin.destroy();
+                            plugin.terminate();
+                        }
                     }
                     _ => {}
                 }
@@ -340,10 +343,10 @@ impl MotionIOPluginController {
             .for_each(|plugin| plugin.destroy())
     }
     pub fn terminate(&mut self) {
-        self.plugins
-            .lock()
-            .iter_mut()
-            .for_each(|plugin| plugin.terminate())
+        let mut guard = self.plugins.lock();
+        while let Some(plugin) = guard.pop() {
+            plugin.terminate();
+        }
     }
     #[allow(unused)]
     pub(super) fn all_plugins_mut(&mut self) -> Arc<Mutex<Vec<MotionIOPlugin>>> {

--- a/rust/plugin_wasm/src/motion/controller.rs
+++ b/rust/plugin_wasm/src/motion/controller.rs
@@ -116,13 +116,17 @@ impl MotionIOPluginController {
                     }
                     notify::EventKind::Remove(_) => {
                         let mut guard = plugins_inner.lock();
-                        let indices = guard.iter().enumerate().filter_map(|(i, plugin)| {
-                            if ev.paths.contains(plugin.path()) {
-                                Some(i)
-                            } else {
-                                None
-                            }
-                        }).collect::<Vec<_>>();
+                        let indices = guard
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(i, plugin)| {
+                                if ev.paths.contains(plugin.path()) {
+                                    Some(i)
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<_>>();
                         for index in indices {
                             let mut plugin = guard.remove(index);
                             tracing::info!(

--- a/rust/plugin_wasm/src/motion/plugin.rs
+++ b/rust/plugin_wasm/src/motion/plugin.rs
@@ -421,7 +421,7 @@ impl MotionIOPlugin {
             &mut self.store,
         )
     }
-    pub fn terminate(&mut self) {
+    pub fn terminate(mut self) {
         inner_terminate_function(
             &self.instance,
             "nanoemApplicationPluginMotionIOTerminate",


### PR DESCRIPTION
## Summary

This PR changes `terminate` method of plugin instances takes ownership to ensure disposing plugin instance.

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
