### PR TITLE
[chore] disable global permissions by default to dependabot and labeler

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,13 +1,15 @@
 name: Dependabot auto-merge
+
 on: pull_request
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,10 @@
 name: "Pull Request Labeler"
+
 on:
   pull_request:
     branches: [ main ]
+
+permissions: {}
 
 jobs:
   triage:


### PR DESCRIPTION
## Summary

This PR disable global permissions to dependabot and labeler based on #497 

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
