### PR TITLE
[github] adds `security-events: write` to CodeQL's permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,10 +8,10 @@ permissions: {}
 
 jobs:
   triage:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v5
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -221,6 +221,8 @@ jobs:
   codeql:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     timeout-minutes: 60
     env:
       CC: clang


### PR DESCRIPTION
## Summary

This PR adds `security-events: write` to [fix an error](https://github.com/hkrn/nanoem/actions/runs/9939336467/job/27453693508).

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
