### PR TITLE
[rust] fixes clippy warnings of `missing_transmute_annotations`

### DIFF
--- a/rust/plugin_wasm/src/model/c_api.rs
+++ b/rust/plugin_wasm/src/model/c_api.rs
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOCreateWithLocation(
         let result = instance.create();
         if result.is_ok() {
             let plugin = Box::new(instance);
-            return unsafe { std::mem::transmute(plugin) };
+            return unsafe { std::mem::transmute::<Box<nanoem_application_plugin_model_io_t>, *mut nanoem_application_plugin_model_io_t>(plugin) };
         }
     }
     null_mut()

--- a/rust/plugin_wasm/src/model/c_api.rs
+++ b/rust/plugin_wasm/src/model/c_api.rs
@@ -51,7 +51,12 @@ pub unsafe extern "C" fn nanoemApplicationPluginModelIOCreateWithLocation(
         let result = instance.create();
         if result.is_ok() {
             let plugin = Box::new(instance);
-            return unsafe { std::mem::transmute::<Box<nanoem_application_plugin_model_io_t>, *mut nanoem_application_plugin_model_io_t>(plugin) };
+            return unsafe {
+                std::mem::transmute::<
+                    Box<nanoem_application_plugin_model_io_t>,
+                    *mut nanoem_application_plugin_model_io_t,
+                >(plugin)
+            };
         }
     }
     null_mut()

--- a/rust/plugin_wasm/src/motion/c_api.rs
+++ b/rust/plugin_wasm/src/motion/c_api.rs
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOCreateWithLocation(
         let result = instance.create();
         if result.is_ok() {
             let plugin = Box::new(instance);
-            return unsafe { std::mem::transmute(plugin) };
+            return unsafe { std::mem::transmute::<Box<nanoem_application_plugin_motion_io_t>, *mut nanoem_application_plugin_motion_io_t>(plugin) };
         }
     }
     null_mut()

--- a/rust/plugin_wasm/src/motion/c_api.rs
+++ b/rust/plugin_wasm/src/motion/c_api.rs
@@ -51,7 +51,12 @@ pub unsafe extern "C" fn nanoemApplicationPluginMotionIOCreateWithLocation(
         let result = instance.create();
         if result.is_ok() {
             let plugin = Box::new(instance);
-            return unsafe { std::mem::transmute::<Box<nanoem_application_plugin_motion_io_t>, *mut nanoem_application_plugin_motion_io_t>(plugin) };
+            return unsafe {
+                std::mem::transmute::<
+                    Box<nanoem_application_plugin_motion_io_t>,
+                    *mut nanoem_application_plugin_motion_io_t,
+                >(plugin)
+            };
         }
     }
     null_mut()


### PR DESCRIPTION
## Summary

This PR fixes `missing_transmute_annotations` warned by clippy.

### Note

* All commits **must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits)** to be merged
* [CI](https://github.com/hkrn/nanoem/actions/workflows/main.yml) **must be passed** to be merged
